### PR TITLE
feat: Wrestler persona duality — the human behind the character

### DIFF
--- a/docs/WRESTLER_PERSONAS_ANALYSIS.md
+++ b/docs/WRESTLER_PERSONAS_ANALYSIS.md
@@ -1,0 +1,256 @@
+# Wrestler Personas Analysis: The Human Behind the Character
+
+## They Were People Before They Were Wrestlers
+
+Every wrestler who steps through the curtain carries two lives. There is the person — born somewhere specific, raised by someone, shaped by experience and circumstance — and there is the character, a constructed identity built for the ring, for the camera, for the crowd. These two lives are not separate. They bleed into each other constantly, sometimes by design and sometimes by accident, creating a unique tension that defines professional wrestling as an art form.
+
+This document examines that duality as it exists within the LLMFed simulation: how we model the real person, how we structure the gimmick, where kayfabe bends and breaks, how social media has created a new arena for identity performance, and what happens when the two lives collide.
+
+---
+
+## Part I: The Real Person
+
+### Origin Stories
+
+Nobody grows up wanting to be a "heel." They grow up wanting to be a wrestler — or they grow up wanting something else entirely and end up in wrestling by accident, desperation, or fate.
+
+The person behind the character has a geography. They came from a small town in Texas or a suburb of Tokyo or a housing project in Atlanta. That geography shaped them — their accent, their toughness, their frame of reference. Some wrestlers come from wrestling families and grew up in the business, watching their parents take bumps and learning to work before they could drive. Others found wrestling late, after failed football careers, after military service, after bouncing at bars and realizing they were big enough and mean enough to make a living getting hit.
+
+**What we model:**
+- **Origin story** — a narrative of where they came from and how they got here
+- **Pre-wrestling career** — what they did before (bouncer, teacher, athlete, nothing)
+- **Family situation** — married, divorced, kids, estranged, supportive
+- **Wrestling motivation** — money, legacy, art, escape, family tradition
+
+### The Worker's True Self
+
+The real person has traits that may align with or completely contradict their character. A monster heel might be the gentlest person in the locker room. A fiery babyface might be a political nightmare backstage. A comedy act might be deeply depressed. These contradictions aren't bugs — they're the engine of the most compelling wrestling stories, even if they never appear on camera.
+
+**Real personality dimensions:**
+- **Temperament** — calm, volatile, anxious, steady
+- **Introversion/Extroversion** — some workers are drained by the performance; others are fueled by it
+- **Ambition** — how hungry they are vs. how content they are with their spot
+- **Ego** — self-assessment vs. reality; how they handle being told "no"
+- **Substance risk** — the industry's dark companion; susceptibility to self-medication
+- **Media savvy** — how well they navigate the public eye outside of kayfabe
+
+### Real Goals vs. Kayfabe Ambitions
+
+The character wants the championship. The person wants financial security for their family. The character wants revenge on their rival. The person wants to prove to their father — who said wrestling wasn't a real career — that they made the right choice. The character is a cocky heel who doesn't need anyone. The person is terrified of being released and having no backup plan.
+
+This tension between real goals and character goals is what makes wrestling stories resonate. When a wrestler cuts a promo about "proving doubters wrong," the best ones are channeling something real. The worst ones are just reading lines.
+
+---
+
+## Part II: The Gimmick as Structure
+
+### Archetype Taxonomy
+
+Every wrestling character maps to one or more archetypes. These aren't limitations — they're foundations. The best gimmicks use the archetype as scaffolding and then build something personal on top.
+
+| Archetype | Core Identity | Promo Voice | Ring Style | Crowd Dynamic |
+|-----------|---------------|-------------|------------|---------------|
+| **Monster Heel** | Unstoppable force of destruction | Few words, menacing, let actions speak | Dominant squashes, power moves | Fear → grudging respect |
+| **Underdog Babyface** | Heart bigger than their body | Emotional, relatable, references struggle | Comeback spots, resilience | Sympathy → elation |
+| **Cocky Technician** | Best wrestler alive and knows it | Condescending, specific, references stats | Chain wrestling, counters, outsmarting | Grudging respect → hatred |
+| **Silent Assassin** | Violence without explanation | Doesn't speak (or speaks rarely, cryptically) | Clinical, efficient, surgical | Unease → fascination |
+| **Cult Leader** | Ideology incarnate | Philosophical, hypnotic, recruitment | Methodical, symbolic | Discomfort → devotion (from followers) |
+| **Comedy Act** | Entertainment first, wrestling second | Self-aware, witty, breaks tension | Slapstick, creative spots | Laughter → surprising pops |
+| **Anti-Hero** | Rejects both face and heel labels | Profane, honest, shoot-adjacent | Brawling, rule-breaking, unpredictable | Confusion → adoration |
+| **Legacy** | Carrying a family name | Respectful, tradition-invoking | Classic style, honoring predecessors | Nostalgia → earned respect |
+| **Patriot** | National/cultural avatar | Rallying, proud, us-vs-them | Power + spectacle | Cheap pops → genuine investment |
+| **Daredevil** | No regard for personal safety | Adrenaline-fueled, cavalier about pain | High spots, ladders, tables, death-defying | Gasps → standing ovations |
+
+### Gimmick Depth Spectrum
+
+Not all gimmicks are created equal in complexity:
+
+**Shallow (depth 0-30):** Costume gimmicks. The wrestler is "a dentist" or "a race car driver." The character has one dimension and one joke. These can work short-term or in comedy roles but have no long-term story potential. The person behind the gimmick has nowhere to go because the character has no interiority.
+
+**Moderate (depth 31-60):** The character has a clear identity with some internal logic. They have motivations, a speech pattern, consistent behavior. But they don't evolve. They're reliable but predictable. Most midcard wrestlers live here. The gimmick serves its purpose but doesn't transcend.
+
+**Deep (depth 61-85):** The character has layers. Their motivations are complex. They can be funny in one segment and terrifying in the next without it feeling wrong. They have a past that informs their present. The audience feels like they *know* this character. The person behind the gimmick has invested genuine creativity and emotional truth into the performance.
+
+**Transcendent (depth 86-100):** The gimmick has become indistinguishable from the person, or the tension between person and character has become the character itself. These are the wrestlers who define eras. The audience isn't sure where the person ends and the character begins — and that uncertainty is the magic.
+
+### Gimmick Evolution Patterns
+
+Characters don't stay static. The best ones evolve:
+
+**Gradual drift** — Alignment slowly shifts. A face gets more aggressive. A heel starts getting cheered and stops fighting it. The gimmick adapts to the audience reaction rather than dictating it.
+
+**Crisis reinvention** — Something breaks. A major loss, a career-threatening injury, a storyline that killed their heat. The wrestler comes back as something new. New music, new look, new name sometimes. The old gimmick is explicitly buried.
+
+**Natural aging** — The young hotshot becomes the grizzled veteran. The daredevil can't fly anymore and becomes a technician. The comedy act gets serious when stakes get real. Time changes what the body can do and what the audience believes.
+
+**Repackaging (forced)** — Creative decides the current gimmick isn't working. The wrestler is taken off TV, given a new character, and re-debuted. This can be a second chance or a death sentence depending on execution.
+
+**Organic deepening** — The gimmick doesn't change, but it gains layers. Through long storylines, the character reveals new dimensions. The monster heel shows vulnerability. The comedy act shows they can go in the ring. The audience's understanding of the character deepens without the character fundamentally changing.
+
+---
+
+## Part III: The Kayfabe Spectrum
+
+### What Kayfabe Actually Is
+
+Kayfabe is the agreement — between performers, between promotion and audience, between the person and the character — that the performance is, on some level, real. It is not a binary. It is a spectrum, and every federation, every wrestler, and every era sits at a different point on that spectrum.
+
+### The Spectrum
+
+```
+FULL KAYFABE                                                    FULL SHOOT
+|---------|---------|---------|---------|---------|---------|---------|
+100       85        70        55        40        25        10        0
+
+Territory  Golden    Attitude   Reality   Modern    Shoot     Podcast
+Era        Era       Era        Era       Era       Style     Era
+```
+
+**Full Kayfabe (85-100):** The character IS the person, publicly. Heels and faces don't travel together. Wrestlers don't break character in public. Injuries are "storyline developments." The audience is treated as if they believe everything. Federations at this level fine workers for breaking character on social media, restrict public appearances, and maintain strict separation between reality and performance.
+
+**Worked Kayfabe (55-84):** The audience knows it's a performance, but everyone agrees to play along. Characters are maintained on TV and in official media, but nobody pretends backstage politics don't exist. The "dirt sheet" exists and is tolerated. Wrestlers might wink at the audience occasionally but don't shatter the illusion.
+
+**Worked Shoots (25-54):** The line is intentionally blurred. Real grievances become storylines. Wrestlers reference their actual contracts, their actual frustrations, their actual personal lives — but within the framework of a produced show. The audience is meant to wonder: "Wait, is this real?" This is where the most electric moments in wrestling history live.
+
+**Shoot Territory (0-24):** The performance acknowledges itself as performance. Wrestlers talk openly about "the business," reference booking decisions, discuss their real feelings about their push. Podcasts, YouTube channels, and shoot interviews live here. The character is abandoned or irrelevant. The person speaks directly.
+
+### Federation-Level Kayfabe Strictness
+
+Different federations enforce kayfabe at different levels:
+
+- **High strictness (70-100):** Social media is monitored. Breaking character has consequences. The show is presented as sport. Commentary sells everything as real. No meta-references.
+- **Medium strictness (40-69):** The show is performance, but characters are maintained during shows. Social media has guidelines but not strict enforcement. Occasional winks to the audience are tolerated.
+- **Low strictness (0-39):** Characters are loose suggestions. Wrestlers can be themselves. Shoot-style promos are encouraged. The federation leans into the "realness" as its brand identity. Meta-commentary is part of the product.
+
+### Character Consistency
+
+How well does a wrestler stay in character? This isn't just about kayfabe commitment — it's about skill. Some wrestlers can maintain a complex character 24/7 because they've internalized it. Others struggle to stay in character for a five-minute promo. This is affected by:
+
+- **Kayfabe commitment** — how much they *want* to protect the character
+- **Character depth** — deeper characters are easier to stay in because there's more to draw from
+- **Personal life stability** — crisis makes it harder to maintain a fiction
+- **Skill** — some people are better actors than others (charisma + mic skill stats)
+
+---
+
+## Part IV: Social Media — The New Arena
+
+### The Third Space
+
+Social media created a space that is neither fully kayfabe nor fully shoot. It's a third space where wrestlers perform identity in a new way. A wrestler's Twitter feed might contain:
+
+- **In-character posts** — trash-talking an opponent, promoting an upcoming match, staying in the gimmick voice. These reinforce the on-screen product.
+- **Shoot posts** — genuine opinions, personal photos, political takes, real emotional expression. These reveal the person.
+- **Worked shoots** — posts that *look* like genuine reactions but are actually strategic. Feuding with someone online to build a match. "Accidentally" revealing frustration with booking to generate buzz.
+- **Ambiguous posts** — the sweet spot. A cryptic tweet that could be in-character or could be a real grievance. Fans dissect these endlessly, generating engagement regardless of intent.
+
+### Viral Moments
+
+Social media has created a new currency: the viral moment. A wrestler who cuts a forgettable promo on TV but drops a perfect tweet afterward might get more attention from the tweet. This affects:
+
+- **Popularity** — viral moments can spike a wrestler's visibility overnight
+- **Fan engagement** — creates parasocial attachment that transcends the show
+- **Storyline fuel** — what happens online can become what happens on TV
+- **Backstage heat** — going viral for the wrong reasons (breaking kayfabe, shooting on coworkers, controversial takes) can create real backstage problems
+
+### The Parasocial Dimension
+
+Social media collapses the distance between performer and audience. Fans feel like they *know* the person behind the character. This creates:
+
+- **Loyalty** — fans who follow the person, not just the character, will follow them across promotions
+- **Vulnerability** — personal struggles that become public generate sympathy but also exploitation potential (by bookers who see "storyline material")
+- **Entitlement** — fans who feel they "know" the wrestler may feel entitled to personal information, to creative decisions, to the wrestler's time
+
+### Platform Behaviors
+
+Different platforms serve different functions:
+
+| Platform | Primary Use | Kayfabe Level | Engagement Type |
+|----------|-------------|---------------|-----------------|
+| Twitter/X | Hot takes, feuds, reactions | Mixed | Rapid-fire, quote-tweet battles |
+| Instagram | Lifestyle, physique, personal life | Mostly shoot | Visual, aspirational |
+| YouTube | Long-form: vlogs, shoot interviews | Varies | Deep engagement, subscription |
+| TikTok | Short clips, behind-the-scenes, humor | Mostly shoot | Viral potential, young audience |
+| Podcast | Extended conversation, storytelling | Shoot-heavy | Intimate, loyal audience |
+
+---
+
+## Part V: Where Two Lives Collide
+
+### The Collision Points
+
+The most compelling moments in wrestling happen at the intersection of the real and the performed. These collision points are where the art form transcends entertainment and becomes something raw and human.
+
+### Personal Tragedy as Storyline Fuel
+
+When a wrestler experiences genuine loss — a death in the family, a divorce, a health scare — it creates a terrible creative opportunity. Some federations exploit this. Some wrestlers choose to channel it. The line between "using art to process pain" and "exploiting trauma for ratings" is razor-thin and constantly debated.
+
+**In the simulation:** Life events with high severity and `is_public=True` become available to the storyline engine. Whether they're used depends on:
+- Federation kayfabe strictness (high-strictness feds are *less* likely to use real events)
+- Wrestler's kayfabe commitment (high-commitment wrestlers will insist on keeping real life separate)
+- Storyline need (a booker desperate for heat might reach for real-life material)
+- The event's narrative potential (some events are too sensitive; others are universal enough to resonate)
+
+### Real Injuries Written Into Kayfabe
+
+A wrestler gets legitimately hurt. The federation has choices:
+1. Acknowledge the injury honestly (shoot approach)
+2. Write the injury into a storyline — an "attack" by a heel explains the absence and builds a return feud (kayfabe approach)
+3. Ignore it and hope nobody notices (denial approach)
+
+The choice depends on the federation's kayfabe level and the wrestler's position. A main eventer's injury becomes a storyline. A midcarder's injury is quietly written off.
+
+### Real Friendships vs. On-Screen Rivalries
+
+Two wrestlers who are genuine close friends are booked into a blood feud. They have to pretend to hate each other on camera, on social media, in public. This tests:
+- Their professionalism
+- Their kayfabe commitment
+- Their friendship (some feuds have damaged real relationships)
+- The audience's suspension of disbelief (smart fans who know they're friends watch for cracks)
+
+### Real Rivalries vs. On-Screen Alliances
+
+Worse: two wrestlers who genuinely dislike each other are booked as a tag team. Every match is a negotiation. Every promo is a test of composure. The tension is palpable but the audience isn't sure if it's performance or reality — which, ironically, makes the eventual breakup *more* compelling.
+
+### When the Character Takes Over
+
+Some wrestlers become their characters. The line between person and performance dissolves. This can be:
+- **Transcendent** — the character is so fully realized that it elevates everything the person does
+- **Destructive** — the person loses themselves in the character, making choices in their real life based on character logic rather than personal wellbeing
+- **Complicated** — usually both, simultaneously
+
+### When the Person Breaks Through
+
+The inverse: a wrestler in the middle of a performance suddenly becomes real. An emotional promo that was supposed to be scripted becomes a genuine confession. A worked-shoot that goes too far and reveals actual pain. A retirement speech where the character is abandoned and the person speaks directly to the audience for the first time in years.
+
+These moments are electric because they violate the contract. The audience came to see a show. Instead, they're witnessing something true. The discomfort and the beauty of that violation is what makes professional wrestling unlike any other performance art.
+
+---
+
+## Implementation in LLMFed
+
+This analysis informs the following systems added to the simulation:
+
+### Data Layer
+- **WrestlerBackstoryDB** — the real person: origin, family, motivation, true personality
+- **GimmickHistoryDB** — character as a versioned entity: archetype, depth, voice, evolution history
+- **LifeEventDB** — personal events that create narrative pressure
+- **SocialMediaPostDB** — the third space between kayfabe and shoot
+- **KayfabeProfileDB** — federation-level kayfabe enforcement
+
+### Service Layer
+- **PersonaService** — manages the duality: backstory generation, gimmick evolution, collision detection
+- **SocialMediaService** — simulates the online arena: posts, virality, engagement
+- Enhanced **PromoService** — archetype-aware voice, emotional modifiers from life events, worked-shoot promos
+- Enhanced **StorylineService** — kayfabe spectrum, real-life storyline sourcing
+- Enhanced **NewsService** — social media drama, persona conflict reporting
+
+### The Core Insight
+
+Wrestling is the only performance art where the audience actively investigates the performer's real life to enhance their experience of the fiction. Smart marks read dirt sheets not to debunk the show but to add layers to their viewing experience. They want to know that a feud is "real" because it makes the worked version better. They want to know that a babyface is genuinely a good person because it makes the cheers feel earned.
+
+The simulation captures this by making the person and the character two distinct-but-entangled entities, each with their own attributes, their own trajectories, and their own relationship to truth. The magic happens in the space between them.
+
+---
+
+*"The best gimmick is yourself, turned up to eleven." — Every wrestling trainer, to every trainee, forever.*

--- a/game_service/news_service.py
+++ b/game_service/news_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from models.game_models import (
     WorldNewsDB, ShowDB, GameFederationDB, GameWrestlerDB,
     GameNarrativeLogDB, ContractDB, ChampionshipDB,
+    SocialMediaPostDB, LifeEventDB, GimmickHistoryDB,
 )
 
 logger = logging.getLogger(__name__)
@@ -186,4 +187,101 @@ def generate_weekly_dirt_sheet(db: Session, world_id: str, game_date: str):
         game_date=game_date,
         is_kayfabe=False,
         source="Wrestling Observer Newsletter",
+    ))
+
+
+def generate_social_media_news(db: Session, world_id: str, game_date: str):
+    """Generate news from viral social media posts."""
+    viral_posts = db.query(SocialMediaPostDB).filter(
+        SocialMediaPostDB.world_id == world_id,
+        SocialMediaPostDB.game_date == game_date,
+        SocialMediaPostDB.is_viral == True,
+    ).all()
+
+    for post in viral_posts:
+        wrestler = db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.id == post.wrestler_id,
+        ).first()
+        if not wrestler:
+            continue
+
+        name = wrestler.name
+        if post.post_type == "shoot":
+            headline = f"VIRAL: {name}'s shoot post breaks the internet!"
+            body = (f'{name} posted what appears to be a genuine, unscripted message '
+                    f'on {post.platform} that has the wrestling world buzzing. '
+                    f'The post has generated massive engagement and debate among fans.')
+        elif post.post_type == "worked_shoot":
+            headline = f"Is {name}'s viral post a work or a shoot? Fans debate"
+            body = (f'A cryptic post from {name} on {post.platform} has fans '
+                    f'divided on whether it\'s a storyline tease or a genuine grievance. '
+                    f'The ambiguity has only fueled more discussion.')
+        else:
+            headline = f"{name}'s {post.platform} post goes viral"
+            body = (f'{name} is trending after a {post.platform} post caught fire. '
+                    f'Fan reaction has been {post.fan_reaction}.')
+
+        db.add(WorldNewsDB(
+            world_id=world_id,
+            headline=headline,
+            body=body,
+            category="social_media",
+            game_date=game_date,
+            is_kayfabe=False,
+            source="Social Media Report",
+            related_entities=[wrestler.id],
+        ))
+
+
+def generate_life_event_news(db: Session, world_id: str, game_date: str):
+    """Generate news from public life events."""
+    public_events = db.query(LifeEventDB).filter(
+        LifeEventDB.world_id == world_id,
+        LifeEventDB.game_date == game_date,
+        LifeEventDB.is_public == True,
+    ).all()
+
+    for event in public_events:
+        wrestler = db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.id == event.wrestler_id,
+        ).first()
+        if not wrestler:
+            continue
+
+        name = wrestler.name
+        positive_types = {"marriage", "child_born", "personal_achievement",
+                          "charity_work", "family_reconciliation"}
+        if event.event_type in positive_types:
+            headline = f"Congratulations! {name} shares personal good news"
+            source = "Wrestling Insider"
+        else:
+            headline = f"Sources say {name} dealing with personal issues"
+            source = "Wrestling Observer"
+
+        db.add(WorldNewsDB(
+            world_id=world_id,
+            headline=headline,
+            body=event.description,
+            category="personal",
+            game_date=game_date,
+            is_kayfabe=False,
+            source=source,
+            related_entities=[wrestler.id],
+        ))
+
+
+def generate_gimmick_change_news(db: Session, world_id: str, wrestler: GameWrestlerDB,
+                                  old_gimmick: str, new_gimmick: str, game_date: str):
+    """Generate news about a wrestler's gimmick change/repackaging."""
+    db.add(WorldNewsDB(
+        world_id=world_id,
+        headline=f"REPACKAGE: {wrestler.name} debuts new character!",
+        body=(f'{wrestler.name} has been repackaged with a new gimmick. '
+              f'The previous "{old_gimmick}" character has been retired. '
+              f'Fans will see the new persona on the next show.'),
+        category="repackage",
+        game_date=game_date,
+        is_kayfabe=False,
+        source="Wrestling Observer",
+        related_entities=[wrestler.id],
     ))

--- a/game_service/persona_service.py
+++ b/game_service/persona_service.py
@@ -1,0 +1,606 @@
+"""
+Persona service — manages the duality between the real person and the wrestling character.
+
+Handles: backstory generation, gimmick creation/evolution, life events,
+persona collision detection, and migration of existing wrestlers.
+"""
+
+import random
+import logging
+from sqlalchemy.orm import Session
+
+from models.game_models import (
+    GameWrestlerDB, WrestlerStatsDB, WrestlerBackstoryDB,
+    GimmickHistoryDB, LifeEventDB, WrestlerRelationshipDB,
+    ContractDB, GameFederationDB, StorylineParticipantDB, StorylineDB,
+    GameNarrativeLogDB,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ARCHETYPES = [
+    "monster_heel", "underdog_face", "cocky_technician", "silent_assassin",
+    "cult_leader", "comedy_act", "anti_hero", "legacy", "patriot", "daredevil",
+]
+
+FAMILY_SITUATIONS = [
+    "single", "married", "married_with_kids", "divorced", "divorced_with_kids",
+    "long_term_relationship", "estranged_family", "close_family",
+]
+
+PRE_WRESTLING_CAREERS = [
+    "bouncer", "amateur_wrestler", "football_player", "military",
+    "teacher", "construction_worker", "personal_trainer", "martial_artist",
+    "actor", "nothing_went_straight_to_wrestling", "college_athlete",
+    "firefighter", "security_guard", "stunt_performer",
+]
+
+MOTIVATIONS = [
+    "passion", "money", "legacy", "escape", "family_tradition",
+    "prove_doubters_wrong", "artistic_expression", "fame", "competition",
+]
+
+TEMPERAMENTS = ["calm", "volatile", "anxious", "steady", "brooding", "cheerful"]
+
+ORIGIN_TEMPLATES = [
+    "Grew up in {hometown}, the {child_pos} of {family_size} siblings. {motivation_story}",
+    "A {pre_career} from {hometown} who found wrestling after {turning_point}.",
+    "Born into a wrestling family in {hometown}. The business is in their blood.",
+    "Came from nothing in {hometown}. Wrestling was the only way out.",
+    "{pre_career} turned wrestler. Left everything behind in {hometown} to chase the dream.",
+    "Trained in a barn in {hometown}. Nobody gave them a chance. They took it anyway.",
+]
+
+TURNING_POINTS = [
+    "a chance encounter at a local show",
+    "losing everything in their previous career",
+    "being told they'd never amount to anything",
+    "watching wrestling as a kid and never letting go of the dream",
+    "a friend dared them to try out at a local school",
+    "recovering from a serious injury and needing a new purpose",
+]
+
+MOTIVATION_STORIES = {
+    "passion": "Fell in love with wrestling watching late-night TV and never looked back.",
+    "money": "Saw the paychecks and knew this was the ticket to a better life.",
+    "legacy": "Determined to carry on the family name in the business.",
+    "escape": "Wrestling was the way out of a life that was going nowhere.",
+    "family_tradition": "Third generation. There was never really another option.",
+    "prove_doubters_wrong": "Everyone said they couldn't. That was all the motivation they needed.",
+    "artistic_expression": "Saw wrestling as storytelling with the body. An art form.",
+    "fame": "Wanted to be known. Wanted the crowd. Wanted the spotlight.",
+    "competition": "Needed to compete. Needed to win. Needed to be the best.",
+}
+
+ARCHETYPE_DESCRIPTIONS = {
+    "monster_heel": "An unstoppable force of destruction who dominates opponents through sheer power and intimidation.",
+    "underdog_face": "The scrappy fighter who never gives up, always finding a way back when all seems lost.",
+    "cocky_technician": "A supremely skilled wrestler who knows exactly how good they are and makes sure everyone else does too.",
+    "silent_assassin": "Says nothing, but their actions in the ring speak volumes. Clinical, efficient, terrifying.",
+    "cult_leader": "A charismatic manipulator who draws followers with ideology and fear.",
+    "comedy_act": "Entertainment incarnate. They might not win every match, but they always win the crowd.",
+    "anti_hero": "Rejects labels. Fights for themselves. The crowd loves them anyway.",
+    "legacy": "Carries the weight of a family name and the expectations that come with it.",
+    "patriot": "Fights for something bigger than themselves. The people's champion.",
+    "daredevil": "No fear, no limits. Will do anything to deliver the most spectacular moments.",
+}
+
+ARCHETYPE_VOICE_STYLES = {
+    "monster_heel": {"vocabulary": "simple", "cadence": "slow_burn", "speech_patterns": ["growling", "short_sentences"], "promo_tempo": "menacing"},
+    "underdog_face": {"vocabulary": "simple", "cadence": "emotional", "speech_patterns": ["passionate", "rising_intensity"], "promo_tempo": "building"},
+    "cocky_technician": {"vocabulary": "elaborate", "cadence": "precise", "speech_patterns": ["condescending", "technical_references"], "promo_tempo": "controlled"},
+    "silent_assassin": {"vocabulary": "minimal", "cadence": "staccato", "speech_patterns": ["whisper", "one_liners"], "promo_tempo": "sparse"},
+    "cult_leader": {"vocabulary": "academic", "cadence": "hypnotic", "speech_patterns": ["preaching", "third_person"], "promo_tempo": "methodical"},
+    "comedy_act": {"vocabulary": "street", "cadence": "rapid_fire", "speech_patterns": ["self_deprecating", "pop_culture"], "promo_tempo": "erratic"},
+    "anti_hero": {"vocabulary": "street", "cadence": "conversational", "speech_patterns": ["profane", "honest"], "promo_tempo": "aggressive"},
+    "legacy": {"vocabulary": "elaborate", "cadence": "measured", "speech_patterns": ["respectful", "tradition_invoking"], "promo_tempo": "dignified"},
+    "patriot": {"vocabulary": "simple", "cadence": "rallying", "speech_patterns": ["inclusive", "motivational"], "promo_tempo": "aggressive"},
+    "daredevil": {"vocabulary": "street", "cadence": "rapid_fire", "speech_patterns": ["excited", "cavalier"], "promo_tempo": "erratic"},
+}
+
+LIFE_EVENT_POOL = {
+    "marriage": {"description": "{name} got married in a private ceremony.", "severity": 4, "morale": 15, "performance": 0, "public_chance": 0.6, "storyline_pot": False},
+    "divorce": {"description": "{name} is going through a divorce.", "severity": 7, "morale": -20, "performance": -5, "public_chance": 0.4, "storyline_pot": True},
+    "child_born": {"description": "{name} welcomed a new baby.", "severity": 5, "morale": 20, "performance": 0, "public_chance": 0.7, "storyline_pot": False},
+    "death_in_family": {"description": "{name} lost a close family member.", "severity": 9, "morale": -25, "performance": -10, "public_chance": 0.5, "storyline_pot": True},
+    "legal_trouble": {"description": "{name} is dealing with legal issues.", "severity": 6, "morale": -15, "performance": -3, "public_chance": 0.7, "storyline_pot": True},
+    "personal_achievement": {"description": "{name} achieved a personal milestone outside of wrestling.", "severity": 3, "morale": 10, "performance": 2, "public_chance": 0.8, "storyline_pot": False},
+    "substance_issue": {"description": "{name} has been struggling with substance abuse issues.", "severity": 8, "morale": -20, "performance": -15, "public_chance": 0.3, "storyline_pot": True},
+    "public_controversy": {"description": "{name} is at the center of a public controversy.", "severity": 6, "morale": -10, "performance": -2, "public_chance": 1.0, "storyline_pot": True},
+    "charity_work": {"description": "{name} made headlines for charitable work in their community.", "severity": 2, "morale": 10, "performance": 0, "public_chance": 0.9, "storyline_pot": False},
+    "outside_media": {"description": "{name} appeared on a mainstream media program.", "severity": 3, "morale": 5, "performance": 0, "public_chance": 1.0, "storyline_pot": False},
+    "financial_trouble": {"description": "{name} is reportedly dealing with financial difficulties.", "severity": 6, "morale": -15, "performance": -3, "public_chance": 0.3, "storyline_pot": True},
+    "mental_health": {"description": "{name} has been open about mental health challenges.", "severity": 7, "morale": -10, "performance": -5, "public_chance": 0.4, "storyline_pot": True},
+    "relationship_start": {"description": "{name} has entered a new relationship.", "severity": 3, "morale": 10, "performance": 0, "public_chance": 0.5, "storyline_pot": False},
+    "relationship_end": {"description": "{name} recently went through a breakup.", "severity": 5, "morale": -10, "performance": -2, "public_chance": 0.3, "storyline_pot": False},
+    "family_reconciliation": {"description": "{name} has reconnected with estranged family members.", "severity": 4, "morale": 15, "performance": 2, "public_chance": 0.4, "storyline_pot": False},
+}
+
+
+# ---------------------------------------------------------------------------
+# Backstory generation
+# ---------------------------------------------------------------------------
+
+def generate_backstory(db: Session, wrestler: GameWrestlerDB) -> WrestlerBackstoryDB:
+    """Create a WrestlerBackstoryDB with randomized but coherent origin."""
+    hometown = wrestler.hometown or "parts unknown"
+    motivation = random.choice(MOTIVATIONS)
+    pre_career = random.choice(PRE_WRESTLING_CAREERS)
+    family_sit = random.choice(FAMILY_SITUATIONS)
+    age = wrestler.age or 25
+
+    # Adjust family situation by age
+    if age < 23:
+        family_sit = random.choice(["single", "close_family", "estranged_family"])
+
+    template = random.choice(ORIGIN_TEMPLATES)
+    origin_story = template.format(
+        hometown=hometown,
+        child_pos=random.choice(["oldest", "youngest", "middle", "only child"]),
+        family_size=random.randint(1, 5),
+        motivation_story=MOTIVATION_STORIES.get(motivation, ""),
+        pre_career=pre_career.replace("_", " "),
+        turning_point=random.choice(TURNING_POINTS),
+    )
+
+    # Generate real personality (distinct from character traits)
+    real_personality = {
+        "temperament": random.choice(TEMPERAMENTS),
+        "introversion": random.randint(10, 90),
+        "ambition": random.randint(30, 100),
+        "ego": random.randint(10, 90),
+        "substance_risk": random.randint(0, 50),
+        "media_savvy": random.randint(10, 90),
+    }
+
+    backstory = WrestlerBackstoryDB(
+        wrestler_id=wrestler.id,
+        origin_story=origin_story,
+        family_situation=family_sit,
+        pre_wrestling_career=pre_career,
+        wrestling_motivation=motivation,
+        real_personality=real_personality,
+        personal_struggles=[],
+        personal_life_stability=random.randint(50, 85),
+    )
+    db.add(backstory)
+    db.flush()
+    return backstory
+
+
+# ---------------------------------------------------------------------------
+# Gimmick generation
+# ---------------------------------------------------------------------------
+
+def _pick_archetype(wrestler):
+    """Pick an archetype based on existing wrestler attributes."""
+    alignment = wrestler.alignment or "face"
+    personality = wrestler.personality_traits or {}
+
+    # Weighted selection based on alignment
+    if alignment == "heel":
+        weights = {
+            "monster_heel": 25, "cocky_technician": 25, "silent_assassin": 15,
+            "cult_leader": 15, "anti_hero": 10, "comedy_act": 5,
+            "legacy": 3, "patriot": 1, "daredevil": 5, "underdog_face": 1,
+        }
+    elif alignment == "face":
+        weights = {
+            "underdog_face": 25, "patriot": 15, "legacy": 15,
+            "daredevil": 15, "anti_hero": 10, "comedy_act": 10,
+            "cocky_technician": 5, "monster_heel": 2, "silent_assassin": 2,
+            "cult_leader": 1,
+        }
+    else:
+        weights = {a: 10 for a in ARCHETYPES}
+        weights["anti_hero"] = 30
+
+    archetypes = list(weights.keys())
+    w = [weights[a] for a in archetypes]
+    return random.choices(archetypes, weights=w, k=1)[0]
+
+
+def generate_initial_gimmick(db: Session, wrestler: GameWrestlerDB,
+                              game_date: str) -> GimmickHistoryDB:
+    """Create the initial GimmickHistoryDB from existing wrestler data."""
+    archetype = _pick_archetype(wrestler)
+
+    description = wrestler.gimmick or ARCHETYPE_DESCRIPTIONS.get(archetype, "")
+    voice_style = ARCHETYPE_VOICE_STYLES.get(archetype, {}).copy()
+
+    # Add wrestler's catchphrase to voice style
+    if wrestler.catchphrase:
+        voice_style["catchphrases"] = [wrestler.catchphrase]
+
+    gimmick = GimmickHistoryDB(
+        wrestler_id=wrestler.id,
+        gimmick_name=wrestler.name,
+        archetype=archetype,
+        description=description,
+        origin_narrative=f"Debuted as a {archetype.replace('_', ' ')}.",
+        alignment=wrestler.alignment or "face",
+        voice_style=voice_style,
+        visual_identity={},
+        start_date=game_date,
+        depth_score=random.randint(20, 60),
+        effectiveness=random.randint(30, 70),
+        staleness=0,
+        fan_investment=max(10, wrestler.popularity // 2),
+        is_active=True,
+    )
+    db.add(gimmick)
+
+    # Update wrestler's character depth
+    wrestler.character_depth = gimmick.depth_score
+    db.flush()
+    return gimmick
+
+
+# ---------------------------------------------------------------------------
+# Life events
+# ---------------------------------------------------------------------------
+
+def generate_life_event(db: Session, wrestler_id: str, world_id: str,
+                        game_date: str) -> LifeEventDB:
+    """Randomly generate a life event (~3% chance per call).
+
+    Event probability is weighted by persona traits.
+    """
+    if random.random() > 0.03:
+        return None
+
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == wrestler_id,
+    ).first()
+    if not wrestler:
+        return None
+
+    backstory = db.query(WrestlerBackstoryDB).filter(
+        WrestlerBackstoryDB.wrestler_id == wrestler_id,
+    ).first()
+
+    # Weight event types by persona
+    real_personality = (backstory.real_personality if backstory else {}) or {}
+    substance_risk = real_personality.get("substance_risk", 20)
+    ambition = real_personality.get("ambition", 50)
+    stability = (backstory.personal_life_stability if backstory else 70) or 70
+
+    weights = {}
+    for event_type, data in LIFE_EVENT_POOL.items():
+        base_weight = 10
+        if event_type == "substance_issue":
+            base_weight = substance_risk // 5
+        elif event_type == "personal_achievement":
+            base_weight = ambition // 10
+        elif event_type in ("divorce", "relationship_end"):
+            base_weight = max(1, (100 - stability) // 10)
+        elif event_type in ("marriage", "child_born", "relationship_start"):
+            base_weight = stability // 10
+        elif event_type == "financial_trouble":
+            base_weight = max(1, (100 - stability) // 8)
+        weights[event_type] = max(1, base_weight)
+
+    event_type = random.choices(
+        list(weights.keys()), weights=list(weights.values()), k=1
+    )[0]
+    template = LIFE_EVENT_POOL[event_type]
+
+    is_public = random.random() < template["public_chance"]
+
+    event = LifeEventDB(
+        wrestler_id=wrestler_id,
+        world_id=world_id,
+        game_date=game_date,
+        event_type=event_type,
+        description=template["description"].format(name=wrestler.name),
+        severity=template["severity"],
+        is_public=is_public,
+        morale_impact=template["morale"],
+        performance_impact=template["performance"],
+        storyline_potential=template["storyline_pot"],
+        was_used_in_storyline=False,
+        is_active=True,
+    )
+    db.add(event)
+    db.flush()
+
+    logger.info("Life event '%s' for %s (public=%s)", event_type, wrestler.name, is_public)
+    return event
+
+
+def process_life_event_effects(db: Session, event: LifeEventDB):
+    """Apply morale/performance deltas from a life event to the wrestler."""
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == event.wrestler_id,
+    ).first()
+    if not wrestler:
+        return
+
+    # Apply morale impact (diminishing over time — event gets less fresh)
+    if event.morale_impact:
+        # Apply a fraction of the impact each tick (event is already active)
+        delta = event.morale_impact // 4  # Spread over ~4 ticks
+        wrestler.morale = max(0, min(100, wrestler.morale + delta))
+
+    # Update backstory stability
+    backstory = db.query(WrestlerBackstoryDB).filter(
+        WrestlerBackstoryDB.wrestler_id == wrestler.id,
+    ).first()
+    if backstory:
+        if event.severity >= 7:
+            backstory.personal_life_stability = max(
+                0, backstory.personal_life_stability - event.severity
+            )
+        elif event.morale_impact > 0:
+            backstory.personal_life_stability = min(
+                100, backstory.personal_life_stability + 2
+            )
+
+    # Auto-resolve low-severity events after creation
+    if event.severity <= 3:
+        event.is_active = False
+
+
+# ---------------------------------------------------------------------------
+# Gimmick staleness & evolution
+# ---------------------------------------------------------------------------
+
+def tick_gimmick_staleness(db: Session, wrestler: GameWrestlerDB, game_date: str):
+    """Increase gimmick staleness over time."""
+    gimmick = db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler.id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+    if not gimmick:
+        return
+
+    # Base staleness increase per week
+    increment = 1
+
+    # High popularity slows staleness
+    if wrestler.popularity > 70:
+        increment = max(0, increment - 1)
+
+    # Low effectiveness accelerates it
+    if gimmick.effectiveness < 30:
+        increment += 1
+
+    # High depth slows staleness (complex characters have more to explore)
+    if gimmick.depth_score > 70:
+        increment = max(0, increment - 1)
+
+    gimmick.staleness = min(100, (gimmick.staleness or 0) + increment)
+
+    # Staleness erodes effectiveness
+    if gimmick.staleness > 60:
+        gimmick.effectiveness = max(0, (gimmick.effectiveness or 50) - 1)
+
+
+def check_repackaging_pressure(db: Session, wrestler: GameWrestlerDB) -> dict:
+    """Check if a wrestler needs a gimmick change. Returns pressure score and reason."""
+    gimmick = db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler.id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+    if not gimmick:
+        return {"pressure": 0, "reason": "no_gimmick"}
+
+    pressure = 0
+    reasons = []
+
+    staleness = gimmick.staleness or 0
+    effectiveness = gimmick.effectiveness or 50
+    fan_investment = gimmick.fan_investment or 30
+
+    if staleness > 70:
+        pressure += 30
+        reasons.append("stale_gimmick")
+    if effectiveness < 25:
+        pressure += 30
+        reasons.append("ineffective_character")
+    if fan_investment < 15:
+        pressure += 20
+        reasons.append("fans_lost_interest")
+    if wrestler.popularity < 20:
+        pressure += 20
+        reasons.append("low_popularity")
+    if wrestler.morale < 25:
+        pressure += 10
+        reasons.append("low_morale")
+
+    reason = reasons[0] if reasons else "none"
+    return {"pressure": min(100, pressure), "reason": reason}
+
+
+def execute_gimmick_change(db: Session, wrestler: GameWrestlerDB,
+                           game_date: str, reason: str = None) -> GimmickHistoryDB:
+    """Retire current gimmick and create a new one."""
+    # Retire current gimmick
+    current = db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler.id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+
+    old_name = None
+    old_archetype = None
+    if current:
+        current.is_active = False
+        current.end_date = game_date
+        current.reason_for_change = reason or "repackaging"
+        old_name = current.gimmick_name
+        old_archetype = current.archetype
+
+    # Pick a different archetype
+    available = [a for a in ARCHETYPES if a != old_archetype]
+    new_archetype = random.choice(available)
+
+    voice_style = ARCHETYPE_VOICE_STYLES.get(new_archetype, {}).copy()
+
+    new_gimmick = GimmickHistoryDB(
+        wrestler_id=wrestler.id,
+        gimmick_name=wrestler.name,  # Keep same ring name usually
+        archetype=new_archetype,
+        description=ARCHETYPE_DESCRIPTIONS.get(new_archetype, ""),
+        origin_narrative=f"Reinvented as a {new_archetype.replace('_', ' ')} after {reason or 'creative direction'}.",
+        alignment=wrestler.alignment,
+        voice_style=voice_style,
+        visual_identity={},
+        start_date=game_date,
+        depth_score=random.randint(20, 45),  # New gimmicks start less deep
+        effectiveness=random.randint(40, 60),
+        staleness=0,
+        fan_investment=random.randint(20, 40),
+        is_active=True,
+    )
+    db.add(new_gimmick)
+
+    wrestler.gimmick_changes = (wrestler.gimmick_changes or 0) + 1
+    wrestler.character_depth = new_gimmick.depth_score
+    wrestler.gimmick = new_gimmick.description
+
+    db.flush()
+
+    # Generate news about the change
+    try:
+        from game_service.news_service import generate_gimmick_change_news
+        generate_gimmick_change_news(
+            db, wrestler.world_id, wrestler,
+            old_name or "unknown", new_gimmick.gimmick_name, game_date,
+        )
+    except Exception as e:
+        logger.warning("Failed to generate gimmick change news: %s", e)
+
+    logger.info("Gimmick change for %s: %s -> %s (%s)",
+                wrestler.name, old_archetype, new_archetype, reason)
+    return new_gimmick
+
+
+def evolve_gimmick(db: Session, wrestler: GameWrestlerDB, game_date: str):
+    """Subtle gimmick evolution: adjust depth and fan investment based on activity."""
+    gimmick = db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler.id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+    if not gimmick:
+        return
+
+    # Depth grows slowly with matches and promos
+    if wrestler.last_booked_date == game_date:
+        gimmick.depth_score = min(100, (gimmick.depth_score or 40) + 1)
+
+    # Fan investment follows popularity trends
+    if wrestler.popularity > 60:
+        gimmick.fan_investment = min(100, (gimmick.fan_investment or 30) + 1)
+    elif wrestler.popularity < 30:
+        gimmick.fan_investment = max(0, (gimmick.fan_investment or 30) - 1)
+
+    # Update wrestler's character depth to match
+    wrestler.character_depth = gimmick.depth_score
+
+
+# ---------------------------------------------------------------------------
+# Collision detection
+# ---------------------------------------------------------------------------
+
+def detect_collision_events(db: Session, wrestler: GameWrestlerDB,
+                           game_date: str) -> list:
+    """Detect when real life and kayfabe conflict for a wrestler.
+
+    Returns list of collision dicts: {type, description, severity}.
+    """
+    collisions = []
+
+    backstory = db.query(WrestlerBackstoryDB).filter(
+        WrestlerBackstoryDB.wrestler_id == wrestler.id,
+    ).first()
+
+    # 1. Personal crisis during active push
+    active_events = db.query(LifeEventDB).filter(
+        LifeEventDB.wrestler_id == wrestler.id,
+        LifeEventDB.is_active == True,
+        LifeEventDB.severity >= 7,
+    ).all()
+
+    if active_events and wrestler.popularity > 60:
+        collisions.append({
+            "type": "crisis_during_push",
+            "description": f"{wrestler.name} is dealing with personal issues while in a top spot",
+            "severity": max(e.severity for e in active_events),
+        })
+
+    # 2. Real friends as kayfabe rivals
+    rels = db.query(WrestlerRelationshipDB).filter(
+        ((WrestlerRelationshipDB.wrestler1_id == wrestler.id) |
+         (WrestlerRelationshipDB.wrestler2_id == wrestler.id)),
+    ).all()
+
+    for rel in rels:
+        real = rel.real_relationship
+        kayfabe = rel.kayfabe_alignment
+        if real == "friends" and kayfabe == "rivals":
+            other_id = rel.wrestler2_id if rel.wrestler1_id == wrestler.id else rel.wrestler1_id
+            other = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == other_id).first()
+            if other:
+                collisions.append({
+                    "type": "friends_as_rivals",
+                    "description": f"{wrestler.name} and {other.name} are real friends booked as enemies",
+                    "severity": 5,
+                })
+        elif real == "enemies" and kayfabe in ("allies", "tag_partners"):
+            other_id = rel.wrestler2_id if rel.wrestler1_id == wrestler.id else rel.wrestler1_id
+            other = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == other_id).first()
+            if other:
+                collisions.append({
+                    "type": "enemies_as_allies",
+                    "description": f"{wrestler.name} and {other.name} actually dislike each other but are booked as allies",
+                    "severity": 7,
+                })
+
+    # 3. Low personal stability + high kayfabe commitment = strain
+    if backstory:
+        stability = backstory.personal_life_stability or 70
+        commitment = wrestler.kayfabe_commitment or 50
+        if stability < 30 and commitment > 70:
+            collisions.append({
+                "type": "facade_cracking",
+                "description": f"{wrestler.name}'s real life is falling apart but they're maintaining character",
+                "severity": 8,
+            })
+
+    return collisions
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+def migrate_existing_wrestlers(db: Session, world_id: str):
+    """Populate backstory and gimmick for wrestlers that don't have them."""
+    wrestlers = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.world_id == world_id,
+        GameWrestlerDB.is_active == True,
+    ).all()
+
+    count = 0
+    for wrestler in wrestlers:
+        backstory = db.query(WrestlerBackstoryDB).filter(
+            WrestlerBackstoryDB.wrestler_id == wrestler.id,
+        ).first()
+        if not backstory:
+            generate_backstory(db, wrestler)
+            count += 1
+
+        gimmick = db.query(GimmickHistoryDB).filter(
+            GimmickHistoryDB.wrestler_id == wrestler.id,
+            GimmickHistoryDB.is_active == True,
+        ).first()
+        if not gimmick:
+            generate_initial_gimmick(db, wrestler, "migration")
+
+    db.flush()
+    logger.info("Migrated %d wrestlers with persona data in world %s", count, world_id)
+    return count

--- a/game_service/promo_service.py
+++ b/game_service/promo_service.py
@@ -1,9 +1,9 @@
 """
 Promo service - generates and evaluates wrestler promos.
 
-In the full implementation, this will call an LLM to generate in-character
-promos based on wrestler personality, storyline context, and player direction.
-For now, it uses templates that produce varied promos based on stats.
+Uses the persona duality system: promos are shaped by the wrestler's gimmick
+archetype, voice style, character depth, and real-life emotional state.
+Falls back to alignment-based templates when persona data is unavailable.
 """
 
 import random
@@ -12,13 +12,14 @@ from sqlalchemy.orm import Session
 
 from models.game_models import (
     PromoDB, GameWrestlerDB, WrestlerStatsDB, StorylineDB,
-    StorylineParticipantDB,
+    StorylineParticipantDB, GimmickHistoryDB, WrestlerBackstoryDB,
+    LifeEventDB,
 )
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Promo templates
+# Legacy alignment-based templates (fallback)
 # ---------------------------------------------------------------------------
 
 FACE_OPENERS = [
@@ -66,9 +67,214 @@ CLOSING_LINES = [
     "Remember this moment!",
 ]
 
+# ---------------------------------------------------------------------------
+# Archetype-specific promo templates
+# ---------------------------------------------------------------------------
+
+ARCHETYPE_OPENERS = {
+    "monster_heel": [
+        "...",
+        "*stares silently at the crowd*",
+        "You should be afraid.",
+        "There is no escape.",
+    ],
+    "underdog_face": [
+        "I know what everyone's thinking. 'There's no way.'",
+        "I wasn't supposed to be here. Nobody gave me a chance.",
+        "Every single person who told me I couldn't? They're watching right now.",
+        "I've been knocked down more times than I can count.",
+    ],
+    "cocky_technician": [
+        "Let me educate you people on something.",
+        "I know more about wrestling in my little finger than this entire roster combined.",
+        "This is a CLINIC, not a match.",
+        "I'm not just better than you. I'm better than everyone who came before you.",
+    ],
+    "silent_assassin": [
+        "*cold stare*",
+        "...",
+        "One word. Pain.",
+    ],
+    "cult_leader": [
+        "My children... my flock... listen to me.",
+        "The truth has been hidden from you. But I see it clearly.",
+        "They want you blind. I want you awake.",
+        "Follow me, and you will never walk in darkness again.",
+    ],
+    "comedy_act": [
+        "So, funny story...",
+        "Before I start — has anyone here ever tried to suplex a vending machine? No? Just me?",
+        "I'm here, I'm weird, and I'm ready to party!",
+        "Look, I know what you're thinking, and yes, I DID eat the catering.",
+    ],
+    "anti_hero": [
+        "I'm not here to be your hero.",
+        "You people want me to play nice? That's not how this works.",
+        "I don't care about your rules. I don't care about your traditions.",
+        "Here's the thing nobody wants to admit...",
+    ],
+    "legacy": [
+        "My family built this business. And I'm not about to let it fall apart.",
+        "I carry a name that means something in this industry.",
+        "My father stood in this very ring. My grandfather built rings like this.",
+        "This isn't just a career for me. This is my heritage.",
+    ],
+    "patriot": [
+        "This one's for every single person watching at home!",
+        "I fight for something bigger than myself!",
+        "I represent every single one of you in this arena!",
+        "There is NOTHING more powerful than fighting for what you believe in!",
+    ],
+    "daredevil": [
+        "You know what I was doing before this match? Climbing the rafters. Just for fun.",
+        "I don't have a plan. I never have a plan. That's what makes this FUN.",
+        "They told me not to do it. So obviously, I'm gonna do it BIGGER.",
+        "Pain? Pain's just the entrance fee for the best ride of your life.",
+    ],
+}
+
+ARCHETYPE_BODIES = {
+    "monster_heel": [
+        "I don't wrestle. I destroy. There's a difference.",
+        "Everyone who has stepped in this ring with me has learned the same lesson.",
+        "Your heroes? I've broken them. Every. Single. One.",
+    ],
+    "underdog_face": [
+        "I've worked harder than anyone in that locker room. And I'll do it again tonight.",
+        "They can hit me with everything they've got. I'll still get back up.",
+        "This isn't about talent. It's about heart. And nobody has more heart than me.",
+    ],
+    "cocky_technician": [
+        "I've studied every counter, every reversal, every escape. There is no move I haven't mastered.",
+        "While they were lifting weights, I was perfecting my craft.",
+        "Wrestling is a science. And I have a PhD.",
+    ],
+    "silent_assassin": [
+        "Actions speak.",
+        "When I'm done, they don't get back up.",
+    ],
+    "cult_leader": [
+        "The system is broken. The people in charge want you complacent. I offer... liberation.",
+        "Every soul I've brought into my family has found purpose. Found meaning.",
+        "They call me dangerous because the truth is always dangerous to liars.",
+    ],
+    "comedy_act": [
+        "Look, I may not be the strongest, the fastest, or the smartest. But I am DEFINITELY the most entertaining.",
+        "My finishing move is called 'The Surprise.' Because honestly, I'm as surprised as you are when I win.",
+        "I've been training. I watched three whole YouTube tutorials this week.",
+    ],
+    "anti_hero": [
+        "I'll fight anyone. Face. Heel. Management. The referee. I don't care.",
+        "They want me to pick a side. I pick MY side.",
+        "I'm not a good guy. I'm not a bad guy. I'm THE guy you don't want to cross.",
+    ],
+    "legacy": [
+        "I've watched tapes of every match in my family's history. I carry that knowledge in this ring.",
+        "The name I carry isn't just a name. It's a promise. A standard.",
+        "I was born for this. Literally. This ring is my birthright.",
+    ],
+    "patriot": [
+        "When I fight, I fight with the strength of everyone who believes in me!",
+        "I've traveled the world, and I've never found anything stronger than the people here.",
+        "They want to take what's ours? They'll have to go through ME first.",
+    ],
+    "daredevil": [
+        "Last week I jumped off a twenty-foot ladder. Next week? Make it thirty.",
+        "My body's held together with tape, dreams, and terrible decisions.",
+        "They say I'm reckless. I say I'm LIVING.",
+    ],
+}
+
+ARCHETYPE_CLOSERS = {
+    "monster_heel": [
+        "*drops the mic and walks away*",
+        "Run.",
+        "This is your only warning.",
+    ],
+    "underdog_face": [
+        "And I will NEVER stop fighting!",
+        "Tonight, we make history!",
+        "For everyone who was ever told 'you can't' — watch me.",
+    ],
+    "cocky_technician": [
+        "Class dismissed.",
+        "You're welcome for the education.",
+        "Take notes.",
+    ],
+    "silent_assassin": [
+        "*exits in silence*",
+        "Tick tock.",
+    ],
+    "cult_leader": [
+        "Join us... or be consumed.",
+        "The awakening is coming.",
+        "Open your eyes.",
+    ],
+    "comedy_act": [
+        "And THAT is why they pay me the medium bucks!",
+        "Thank you, I'll be here all week! Literally, I live in the arena now.",
+        "Goodnight everybody! ...Wait, the show's not over? Awkward.",
+    ],
+    "anti_hero": [
+        "Deal with it.",
+        "And if anyone has a problem with that, I'll be right here.",
+        "Your move.",
+    ],
+    "legacy": [
+        "For the family. For the legacy. Forever.",
+        "The tradition continues.",
+        "This chapter isn't over. It's just beginning.",
+    ],
+    "patriot": [
+        "For all of you!",
+        "Together, we are UNSTOPPABLE!",
+        "God bless every one of you!",
+    ],
+    "daredevil": [
+        "See you at the top... or the bottom. Either way, it'll be a RIDE!",
+        "No fear. No limits. No regrets.",
+        "Let's GO!",
+    ],
+}
+
+# Emotional modifiers when life events bleed into promos
+EMOTIONAL_BLEED_LINES = {
+    "grief": [
+        "I've been going through something... something real. And it's given me a fire I didn't know I had.",
+        "There are things happening outside this ring that put EVERYTHING in perspective.",
+        "You think this match scares me? I've faced worse this week than anything you can throw at me.",
+    ],
+    "anger": [
+        "I'm not in the mood for games tonight. Not tonight.",
+        "Somebody backstage needs to hear this — I am DONE being patient.",
+        "If you think I've been intense before, you haven't seen ANYTHING yet.",
+    ],
+    "joy": [
+        "I'm on top of the world right now, and NOTHING is bringing me down!",
+        "Life is good. And it's about to get even better.",
+        "I've got something special waiting for me at home, and that makes me fight HARDER.",
+    ],
+    "desperation": [
+        "I need this. I NEED this more than you'll ever understand.",
+        "This isn't about titles or glory anymore. This is about survival.",
+        "I've got nothing left to lose. And that makes me the most dangerous person in this building.",
+    ],
+}
+
+# Worked-shoot promo fragments
+WORKED_SHOOT_FRAGMENTS = [
+    "You know what? I'm tired of reading scripts.",
+    "This isn't a promo. This is ME talking.",
+    "They told me not to say this, but I don't care anymore.",
+    "You want real? HERE'S real.",
+    "Forget the character. Forget the gimmick. I'm {real_name}, and I have something to say.",
+    "Everyone in that locker room knows the truth. It's time the fans did too.",
+    "I've been holding this in for months. Not anymore.",
+]
+
 
 # ---------------------------------------------------------------------------
-# Promo generation (template-based, LLM-ready)
+# Promo generation (persona-aware, with legacy fallback)
 # ---------------------------------------------------------------------------
 
 def generate_promo(db: Session, world_id: str, wrestler_id: str,
@@ -81,7 +287,7 @@ def generate_promo(db: Session, world_id: str, wrestler_id: str,
     """Generate a promo for a wrestler.
 
     If player_content is provided, use that directly.
-    Otherwise, generate from templates based on wrestler personality.
+    Otherwise, generate from archetype templates (with legacy fallback).
     """
     wrestler = db.query(GameWrestlerDB).filter(
         GameWrestlerDB.id == wrestler_id
@@ -96,19 +302,15 @@ def generate_promo(db: Session, world_id: str, wrestler_id: str,
     if player_content:
         content = player_content
     else:
-        content = _generate_template_promo(wrestler, stats, target_wrestler_id, db)
+        content = _generate_persona_promo(wrestler, stats, target_wrestler_id, db, promo_type)
 
     # Evaluate promo quality
-    quality = _evaluate_promo_quality(stats, content, is_player_written)
+    gimmick = _get_current_gimmick(db, wrestler_id)
+    quality = _evaluate_promo_quality(stats, content, is_player_written, gimmick)
     heat = _calculate_promo_heat(wrestler, quality, target_wrestler_id is not None)
 
-    # Crowd reaction based on alignment
-    if wrestler.alignment == "face":
-        crowd = "pop" if quality >= 3.0 else "mild_pop"
-    elif wrestler.alignment == "heel":
-        crowd = "heat" if quality >= 3.0 else "mild_heat"
-    else:
-        crowd = "mixed"
+    # Crowd reaction: persona-aware
+    crowd = _determine_crowd_reaction(wrestler, quality, promo_type, gimmick)
 
     promo = PromoDB(
         world_id=world_id,
@@ -130,31 +332,110 @@ def generate_promo(db: Session, world_id: str, wrestler_id: str,
     pop_change = int((quality - 2.5) * 2)
     wrestler.popularity = max(0, min(100, wrestler.popularity + pop_change))
 
+    # Evolve gimmick effectiveness based on promo quality
+    if gimmick:
+        if quality >= 3.5:
+            gimmick.effectiveness = min(100, gimmick.effectiveness + 1)
+            gimmick.fan_investment = min(100, gimmick.fan_investment + 1)
+        elif quality < 2.0:
+            gimmick.effectiveness = max(0, gimmick.effectiveness - 1)
+
     return promo
 
 
-def _generate_template_promo(wrestler, stats, target_id, db):
-    """Generate a promo from templates based on wrestler personality."""
+def _get_current_gimmick(db, wrestler_id):
+    """Get the wrestler's current active gimmick, if any."""
+    return db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler_id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+
+
+def _get_active_life_events(db, wrestler_id):
+    """Get active life events affecting the wrestler."""
+    return db.query(LifeEventDB).filter(
+        LifeEventDB.wrestler_id == wrestler_id,
+        LifeEventDB.is_active == True,
+    ).all()
+
+
+def _determine_emotional_state(life_events, kayfabe_commitment):
+    """Determine if real-life emotion bleeds into the promo."""
+    if not life_events:
+        return None
+
+    # Higher kayfabe commitment = less bleed-through
+    bleed_chance = max(0, (100 - kayfabe_commitment)) / 100.0
+
+    severe_events = [e for e in life_events if e.severity >= 7]
+    if not severe_events:
+        return None
+
+    if random.random() > bleed_chance:
+        return None
+
+    event = severe_events[0]
+    negative_types = {"divorce", "death_in_family", "legal_trouble", "substance_issue",
+                      "financial_trouble", "mental_health", "public_controversy"}
+    positive_types = {"marriage", "child_born", "personal_achievement", "charity_work",
+                      "family_reconciliation"}
+
+    if event.event_type in negative_types:
+        if event.severity >= 9:
+            return "desperation"
+        elif event.morale_impact < -10:
+            return "grief"
+        else:
+            return "anger"
+    elif event.event_type in positive_types:
+        return "joy"
+    return None
+
+
+def _generate_persona_promo(wrestler, stats, target_id, db, promo_type):
+    """Generate a promo using the persona duality system.
+
+    Priority: archetype voice > emotional state > alignment fallback.
+    """
+    gimmick = _get_current_gimmick(db, wrestler.id)
+
+    # If no gimmick data, fall back to legacy system
+    if not gimmick or gimmick.archetype not in ARCHETYPE_OPENERS:
+        return _generate_template_promo(wrestler, stats, target_id, db)
+
+    archetype = gimmick.archetype
     parts = []
 
-    # Opener based on alignment
-    if wrestler.alignment == "face":
-        parts.append(random.choice(FACE_OPENERS))
-    elif wrestler.alignment == "heel":
-        parts.append(random.choice(HEEL_OPENERS))
-    else:
-        parts.append(random.choice(FACE_OPENERS + HEEL_OPENERS))
+    # Check for worked-shoot promo (low kayfabe commitment + high frustration/life events)
+    if promo_type == "worked_shoot" or (
+        wrestler.kayfabe_commitment < 30
+        and random.random() < 0.15
+    ):
+        return _generate_worked_shoot_promo(wrestler, gimmick, target_id, db)
 
-    # Middle section based on personality/stats
-    charisma = stats.charisma if stats else 50
-    if charisma > 70:
-        parts.append(random.choice(BOAST_LINES))
-    elif charisma < 30:
-        parts.append(random.choice(UNDERDOG_LINES))
-    else:
-        parts.append(random.choice(BOAST_LINES + UNDERDOG_LINES))
+    # Check emotional bleed from life events
+    life_events = _get_active_life_events(db, wrestler.id)
+    emotional_state = _determine_emotional_state(
+        life_events, wrestler.kayfabe_commitment
+    )
 
-    # Target callout
+    # Opener — archetype-specific
+    parts.append(random.choice(ARCHETYPE_OPENERS[archetype]))
+
+    # Emotional modifier if real life is bleeding through
+    if emotional_state and emotional_state in EMOTIONAL_BLEED_LINES:
+        parts.append(random.choice(EMOTIONAL_BLEED_LINES[emotional_state]))
+
+    # Body — archetype-specific
+    parts.append(random.choice(ARCHETYPE_BODIES[archetype]))
+
+    # Catchphrase insertion if the gimmick has one
+    voice = gimmick.voice_style or {}
+    catchphrases = voice.get("catchphrases", [])
+    if catchphrases and random.random() < 0.4:
+        parts.append(random.choice(catchphrases))
+
+    # Target callout — still uses the universal challenge lines but flavored
     if target_id:
         target = db.query(GameWrestlerDB).filter(
             GameWrestlerDB.id == target_id
@@ -163,21 +444,91 @@ def _generate_template_promo(wrestler, stats, target_id, db):
             line = random.choice(CHALLENGE_LINES).format(target=target.name)
             parts.append(line)
 
-    # Closer
+    # Closer — archetype-specific
+    parts.append(random.choice(ARCHETYPE_CLOSERS[archetype]))
+
+    return " ".join(parts)
+
+
+def _generate_worked_shoot_promo(wrestler, gimmick, target_id, db):
+    """Generate a worked-shoot promo that blurs kayfabe lines."""
+    parts = []
+
+    real_name = wrestler.real_name or wrestler.name
+    fragment = random.choice(WORKED_SHOOT_FRAGMENTS).format(real_name=real_name)
+    parts.append(fragment)
+
+    # Mix in real grievances
+    life_events = _get_active_life_events(db, wrestler.id)
+    if life_events:
+        event = random.choice(life_events)
+        if event.is_public:
+            parts.append(f"Everyone knows what I've been dealing with. And instead of support, what do I get? More matches, more promos, more demands.")
+    else:
+        parts.append("I've given everything to this company. EVERYTHING. And what do I have to show for it?")
+
+    if wrestler.morale < 40:
+        parts.append("I'm tired. Not 'storyline tired.' Really, genuinely TIRED.")
+    elif wrestler.popularity > 70:
+        parts.append("I don't need this. I could walk out that door right now and every company in the world would be calling.")
+
+    if target_id:
+        target = db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.id == target_id
+        ).first()
+        if target:
+            parts.append(f"And {target.name} — forget the storyline. You and I both know what this is really about.")
+
+    parts.append("This is real. Whether you believe it or not.")
+
+    # Track the kayfabe break
+    wrestler.kayfabe_break_count = (wrestler.kayfabe_break_count or 0) + 1
+
+    return " ".join(parts)
+
+
+def _generate_template_promo(wrestler, stats, target_id, db):
+    """Legacy: generate a promo from alignment-based templates."""
+    parts = []
+
+    if wrestler.alignment == "face":
+        parts.append(random.choice(FACE_OPENERS))
+    elif wrestler.alignment == "heel":
+        parts.append(random.choice(HEEL_OPENERS))
+    else:
+        parts.append(random.choice(FACE_OPENERS + HEEL_OPENERS))
+
+    charisma = stats.charisma if stats else 50
+    if charisma > 70:
+        parts.append(random.choice(BOAST_LINES))
+    elif charisma < 30:
+        parts.append(random.choice(UNDERDOG_LINES))
+    else:
+        parts.append(random.choice(BOAST_LINES + UNDERDOG_LINES))
+
+    if target_id:
+        target = db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.id == target_id
+        ).first()
+        if target:
+            line = random.choice(CHALLENGE_LINES).format(target=target.name)
+            parts.append(line)
+
     parts.append(random.choice(CLOSING_LINES))
 
     return " ".join(parts)
 
 
-def _evaluate_promo_quality(stats, content: str, is_player: bool) -> float:
-    """Rate a promo 0.0 - 5.0 based on wrestler stats and content."""
+def _evaluate_promo_quality(stats, content: str, is_player: bool,
+                            gimmick=None) -> float:
+    """Rate a promo 0.0 - 5.0 based on wrestler stats, content, and character depth."""
     mic = stats.mic_skill if stats else 50
     charisma = stats.charisma if stats else 50
 
     # Base quality from stats
     base = ((mic + charisma) / 2) / 100 * 3.5  # 0 - 3.5
 
-    # Length bonus (longer promos that aren't too long)
+    # Length bonus
     word_count = len(content.split())
     if 30 <= word_count <= 150:
         base += 0.5
@@ -187,6 +538,19 @@ def _evaluate_promo_quality(stats, content: str, is_player: bool) -> float:
     # Player promos get a small creativity bonus
     if is_player:
         base += 0.3
+
+    # Gimmick depth bonus: deeper characters produce richer promos
+    if gimmick:
+        depth_bonus = (gimmick.depth_score or 0) / 100 * 0.5  # Up to +0.5
+        base += depth_bonus
+
+        # Effective gimmick bonus
+        if (gimmick.effectiveness or 0) > 70:
+            base += 0.2
+
+        # Stale gimmick penalty
+        if (gimmick.staleness or 0) > 70:
+            base -= 0.3
 
     # Randomness factor
     base += random.uniform(-0.3, 0.5)
@@ -202,9 +566,37 @@ def _calculate_promo_heat(wrestler, quality: float, has_target: bool) -> int:
         base += random.randint(3, 8)
 
     if wrestler.alignment == "heel":
-        base += 3  # Heels generate more heat
+        base += 3
 
     if wrestler.popularity > 70:
-        base += 5  # Popular wrestlers get bigger reactions
+        base += 5
+
+    # Kayfabe breaks generate extra heat (pipe bomb effect)
+    if (wrestler.kayfabe_break_count or 0) > 0 and random.random() < 0.3:
+        base += random.randint(5, 15)
 
     return max(0, min(50, base + random.randint(-3, 3)))
+
+
+def _determine_crowd_reaction(wrestler, quality, promo_type, gimmick):
+    """Determine crowd reaction based on persona context."""
+    # Worked shoots get special reactions
+    if promo_type == "worked_shoot":
+        if quality >= 3.5:
+            return "stunned_silence_then_eruption"
+        return "confused"
+
+    # Anti-heroes always get mixed reactions
+    if gimmick and gimmick.archetype == "anti_hero":
+        return "mixed" if quality < 3.0 else "electric"
+
+    # Comedy acts get unique reactions
+    if gimmick and gimmick.archetype == "comedy_act":
+        return "laughter" if quality >= 2.5 else "crickets"
+
+    # Standard alignment-based reactions
+    if wrestler.alignment == "face":
+        return "pop" if quality >= 3.0 else "mild_pop"
+    elif wrestler.alignment == "heel":
+        return "heat" if quality >= 3.0 else "mild_heat"
+    return "mixed"

--- a/game_service/social_media_service.py
+++ b/game_service/social_media_service.py
@@ -1,0 +1,352 @@
+"""
+Social media service — simulates wrestler social media activity.
+
+Generates in-character, shoot, and worked-shoot posts. Handles viral moments,
+feud exchanges, and fan engagement tracking.
+"""
+
+import random
+import logging
+from sqlalchemy.orm import Session
+
+from models.game_models import (
+    GameWrestlerDB, SocialMediaPostDB, GimmickHistoryDB,
+    WrestlerBackstoryDB, StorylineDB, StorylineParticipantDB,
+    WrestlerRelationshipDB, WorldNewsDB,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Template pools
+# ---------------------------------------------------------------------------
+
+KAYFABE_FACE_POSTS = [
+    "Tonight I fight for every single one of you. Let's DO this! #NeverGiveUp",
+    "Hard work beats talent when talent doesn't work hard. See you in the ring.",
+    "To every kid watching at home — you CAN do this. Believe in yourself.",
+    "Just finished the best training session of my life. I'm coming for that title.",
+    "The people deserve a champion who fights for THEM. That's me.",
+    "Win, lose, or draw — I leave everything in that ring. Every. Single. Night.",
+]
+
+KAYFABE_HEEL_POSTS = [
+    "None of you deserve to breathe the same air as me. #BowDown",
+    "Another day, another roster full of people who can't touch me.",
+    "I don't need your cheers. I need your FEAR.",
+    "Looking at the competition and honestly? I'm insulted.",
+    "Your hero? I already beat them. Twice.",
+    "The only thing more pathetic than this roster is the fans who cheer for them.",
+]
+
+SHOOT_POSTS = [
+    "Great day at the gym. Grateful for this life.",
+    "Nothing better than a day off with the family.",
+    "Throwing it back to where it all started. Long way from {hometown}.",
+    "Real talk — this industry tests you. But I love it.",
+    "Watching the new generation come up. The future's bright.",
+    "Rest day. My body needed this more than I want to admit.",
+    "Appreciating the little things today. This business can take a lot from you.",
+]
+
+WORKED_SHOOT_POSTS = [
+    "Funny how some people get opportunities and others don't. Just saying.",
+    "I've been very patient. That patience is running out.",
+    "Sometimes I wonder if anyone backstage is actually watching the show...",
+    "...",
+    "When you're ready to have a REAL conversation, you know where to find me.",
+    "I wasn't supposed to say this but I genuinely don't care anymore.",
+    "The best match on the card and we got 8 minutes. Interesting.",
+]
+
+PERSONAL_POSTS = [
+    "Took the kids to the park today. Best part of my week.",
+    "Happy anniversary to the love of my life. You make this all worth it.",
+    "Lost someone special this week. Hug the people you love.",
+    "New hobby alert: apparently I'm a terrible cook but I'm not giving up.",
+    "Dog update: still the best part of coming home from the road.",
+    "Reading recommendation from the road: currently on my third book this month.",
+]
+
+CHALLENGE_POSTS = [
+    "Hey {target} — you've been real quiet since I called you out. Cat got your tongue?",
+    "{target} ducking me on social media just like they duck me in the ring.",
+    "Everywhere I go, people ask me the same thing: 'When are you gonna shut {target} up?' Soon.",
+    "I see {target} posted another selfie. Must be nice having free time when you don't have MY schedule.",
+]
+
+RESPONSE_POSTS = [
+    "LOL {target} is talking again. Wake me up when they actually win a match.",
+    "{target} wants attention so bad. Fine. You got it. And you'll regret it.",
+    "The difference between me and {target}? I let my record speak for itself.",
+    "Cute post, {target}. Real cute. See you at the show.",
+]
+
+
+# ---------------------------------------------------------------------------
+# Post generation
+# ---------------------------------------------------------------------------
+
+def generate_social_post(db: Session, wrestler_id: str, world_id: str,
+                         game_date: str, context: str = None) -> SocialMediaPostDB:
+    """Generate a social media post for a wrestler."""
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == wrestler_id,
+    ).first()
+    if not wrestler:
+        return None
+
+    gimmick = db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler_id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+
+    backstory = db.query(WrestlerBackstoryDB).filter(
+        WrestlerBackstoryDB.wrestler_id == wrestler_id,
+    ).first()
+
+    # Determine post type based on kayfabe commitment
+    kayfabe_commit = wrestler.kayfabe_commitment or 50
+    roll = random.random() * 100
+
+    if roll < kayfabe_commit * 0.6:
+        post_type = "kayfabe"
+    elif roll < kayfabe_commit * 0.6 + 20:
+        post_type = "personal"
+    elif roll < kayfabe_commit * 0.6 + 35:
+        post_type = "shoot"
+    else:
+        post_type = "worked_shoot"
+
+    # Generate content
+    content = _generate_post_content(wrestler, gimmick, backstory, post_type)
+
+    # Platform selection
+    platform = random.choices(
+        ["twitter", "instagram", "tiktok", "youtube"],
+        weights=[40, 30, 20, 10], k=1,
+    )[0]
+
+    # Engagement based on popularity and content type
+    base_engagement = wrestler.popularity // 3
+    if post_type == "worked_shoot":
+        base_engagement += random.randint(10, 30)
+    elif post_type == "shoot" and backstory:
+        media_savvy = (backstory.real_personality or {}).get("media_savvy", 50)
+        base_engagement += media_savvy // 10
+    engagement = min(100, base_engagement + random.randint(-5, 15))
+
+    # Controversy
+    controversy = 0
+    if post_type == "worked_shoot":
+        controversy = random.randint(20, 60)
+    elif post_type == "shoot":
+        controversy = random.randint(0, 20)
+    elif post_type == "kayfabe" and wrestler.alignment == "heel":
+        controversy = random.randint(5, 25)
+
+    # Kayfabe break level
+    kayfabe_break = 0
+    if post_type == "shoot":
+        kayfabe_break = random.randint(30, 70)
+    elif post_type == "worked_shoot":
+        kayfabe_break = random.randint(40, 80)
+
+    # Fan reaction
+    if post_type == "worked_shoot":
+        fan_reaction = random.choice(["confused", "mixed", "negative", "positive"])
+    elif wrestler.alignment == "face":
+        fan_reaction = "positive" if engagement > 30 else "mixed"
+    elif wrestler.alignment == "heel":
+        fan_reaction = "negative" if engagement > 30 else "mixed"
+    else:
+        fan_reaction = "mixed"
+
+    post = SocialMediaPostDB(
+        wrestler_id=wrestler_id,
+        world_id=world_id,
+        game_date=game_date,
+        content=content,
+        post_type=post_type,
+        platform=platform,
+        engagement_score=engagement,
+        controversy_level=controversy,
+        is_viral=False,
+        fan_reaction=fan_reaction,
+        kayfabe_break_level=kayfabe_break,
+        popularity_impact=0,
+    )
+    db.add(post)
+    db.flush()
+
+    # Check if it goes viral
+    if check_viral_moment(post):
+        post.is_viral = True
+        process_viral_fallout(db, post, game_date)
+
+    return post
+
+
+def _generate_post_content(wrestler, gimmick, backstory, post_type):
+    """Generate post content based on type and persona."""
+    hometown = wrestler.hometown or "the road"
+
+    if post_type == "kayfabe":
+        if wrestler.alignment == "heel":
+            return random.choice(KAYFABE_HEEL_POSTS)
+        return random.choice(KAYFABE_FACE_POSTS)
+    elif post_type == "shoot":
+        template = random.choice(SHOOT_POSTS)
+        return template.format(hometown=hometown)
+    elif post_type == "worked_shoot":
+        return random.choice(WORKED_SHOOT_POSTS)
+    elif post_type == "personal":
+        return random.choice(PERSONAL_POSTS)
+    return "..."
+
+
+# ---------------------------------------------------------------------------
+# Daily tick
+# ---------------------------------------------------------------------------
+
+def tick_social_media(db: Session, world_id: str, game_date: str):
+    """Daily social media tick. Each wrestler has a chance to post."""
+    wrestlers = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.world_id == world_id,
+        GameWrestlerDB.is_active == True,
+    ).all()
+
+    for wrestler in wrestlers:
+        # Base posting chance: 8% per day (~1-2 posts per week per wrestler)
+        chance = 0.08
+
+        # More popular wrestlers post more
+        if wrestler.popularity > 70:
+            chance += 0.05
+        elif wrestler.popularity < 30:
+            chance -= 0.03
+
+        # Higher social media following = more active
+        if (wrestler.social_media_following or 0) > 50000:
+            chance += 0.03
+
+        if random.random() < chance:
+            generate_social_post(db, wrestler.id, world_id, game_date)
+
+    # Check for feud exchanges (active storylines generate social media beef)
+    active_storylines = db.query(StorylineDB).filter(
+        StorylineDB.world_id == world_id,
+        StorylineDB.status.in_(["active", "climax"]),
+    ).all()
+
+    for storyline in active_storylines:
+        # 10% chance of a social media exchange per active storyline per day
+        if random.random() > 0.10:
+            continue
+
+        participants = db.query(StorylineParticipantDB).filter(
+            StorylineParticipantDB.storyline_id == storyline.id,
+        ).all()
+        if len(participants) < 2:
+            continue
+
+        w1_id = participants[0].wrestler_id
+        w2_id = participants[1].wrestler_id
+        generate_feud_exchange(
+            db, w1_id, w2_id, world_id, game_date, storyline.id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Viral moments
+# ---------------------------------------------------------------------------
+
+def check_viral_moment(post: SocialMediaPostDB) -> bool:
+    """Determine if a post goes viral."""
+    chance = 0.02  # Base 2% chance
+
+    if post.controversy_level > 50:
+        chance += 0.10
+    if post.engagement_score > 70:
+        chance += 0.08
+    if post.post_type == "worked_shoot":
+        chance += 0.05
+    if post.kayfabe_break_level > 60:
+        chance += 0.05
+
+    return random.random() < chance
+
+
+def process_viral_fallout(db: Session, post: SocialMediaPostDB, game_date: str):
+    """Handle the effects of a viral post."""
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == post.wrestler_id,
+    ).first()
+    if not wrestler:
+        return
+
+    # Popularity impact
+    if post.controversy_level > 50:
+        # Controversial viral — could go either way
+        pop_change = random.randint(-5, 10)
+    else:
+        pop_change = random.randint(3, 12)
+
+    wrestler.popularity = max(0, min(100, wrestler.popularity + pop_change))
+    wrestler.social_media_following = (wrestler.social_media_following or 1000) + random.randint(500, 5000)
+    post.popularity_impact = pop_change
+
+    # Generate news
+    try:
+        from game_service.news_service import generate_social_media_news
+        generate_social_media_news(db, post.world_id, game_date)
+    except Exception as e:
+        logger.warning("Failed to generate social media news: %s", e)
+
+    logger.info("Viral post by %s! Pop change: %+d", wrestler.name, pop_change)
+
+
+# ---------------------------------------------------------------------------
+# Feud exchanges
+# ---------------------------------------------------------------------------
+
+def generate_feud_exchange(db: Session, wrestler1_id: str, wrestler2_id: str,
+                           world_id: str, game_date: str,
+                           storyline_id: str = None) -> list:
+    """Create a back-and-forth social media exchange between feuding wrestlers."""
+    w1 = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == wrestler1_id).first()
+    w2 = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == wrestler2_id).first()
+    if not w1 or not w2:
+        return []
+
+    posts = []
+    platform = random.choice(["twitter", "twitter", "instagram"])
+
+    # First salvo
+    content1 = random.choice(CHALLENGE_POSTS).format(target=w2.name)
+    post1 = SocialMediaPostDB(
+        wrestler_id=w1.id, world_id=world_id, game_date=game_date,
+        content=content1, post_type="kayfabe", platform=platform,
+        engagement_score=random.randint(30, 70),
+        controversy_level=random.randint(10, 40),
+        storyline_id=storyline_id, target_wrestler_id=w2.id,
+        fan_reaction="positive" if w1.alignment == "face" else "negative",
+    )
+    db.add(post1)
+    posts.append(post1)
+
+    # Response
+    content2 = random.choice(RESPONSE_POSTS).format(target=w1.name)
+    post2 = SocialMediaPostDB(
+        wrestler_id=w2.id, world_id=world_id, game_date=game_date,
+        content=content2, post_type="kayfabe", platform=platform,
+        engagement_score=random.randint(30, 70),
+        controversy_level=random.randint(10, 40),
+        storyline_id=storyline_id, target_wrestler_id=w1.id,
+        fan_reaction="positive" if w2.alignment == "face" else "negative",
+    )
+    db.add(post2)
+    posts.append(post2)
+
+    db.flush()
+    return posts

--- a/game_service/storyline_service.py
+++ b/game_service/storyline_service.py
@@ -13,7 +13,8 @@ from sqlalchemy.orm import Session
 from models.game_models import (
     StorylineDB, StorylineParticipantDB, GameWrestlerDB, GameFederationDB,
     ContractDB, MatchDB, MatchParticipantDB, ChampionshipDB,
-    GameNarrativeLogDB,
+    GameNarrativeLogDB, LifeEventDB, WrestlerRelationshipDB,
+    WrestlerBackstoryDB,
 )
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,8 @@ STORYLINE_NAMES = {
 def create_storyline(db: Session, world_id: str, federation_id: str,
                      wrestler_ids: list, storyline_type: str = "feud",
                      name: str = None, description: str = None,
-                     game_date: str = None) -> StorylineDB:
+                     game_date: str = None,
+                     kayfabe_level: int = 100) -> StorylineDB:
     """Create a new storyline between wrestlers."""
     if not name:
         names = STORYLINE_NAMES.get(storyline_type, STORYLINE_NAMES["feud"])
@@ -112,6 +114,7 @@ def create_storyline(db: Session, world_id: str, federation_id: str,
         description=description,
         heat=random.randint(30, 50),
         start_date=game_date,
+        kayfabe_level=kayfabe_level,
     )
     db.add(storyline)
     db.flush()
@@ -303,3 +306,171 @@ def _find_storyline_between(db: Session, w1_id: str, w2_id: str):
         StorylineDB.id.in_(common),
         StorylineDB.status.in_(["brewing", "active", "climax"]),
     ).first()
+
+
+# ---------------------------------------------------------------------------
+# Kayfabe spectrum: worked-shoot storylines from real events
+# ---------------------------------------------------------------------------
+
+WORKED_SHOOT_NAMES = [
+    "Breaking Point", "Shoot to Kill", "Off Script", "Real Talk",
+    "Behind the Curtain", "No Character Required", "The Unscripted",
+]
+
+WORKED_SHOOT_DESCRIPTIONS = [
+    "What started as a real backstage conflict has become the hottest angle in the company.",
+    "The lines between real life and storyline have blurred beyond recognition.",
+    "Nobody is sure what's real and what's a work anymore — and that's the point.",
+    "A personal grievance has spilled over into the ring.",
+]
+
+
+def check_life_event_storylines(db: Session, world_id: str, game_date: str):
+    """Check if any public life events should become worked-shoot storylines.
+
+    Only fires for federations with low-to-medium kayfabe strictness.
+    """
+    new_storylines = []
+
+    # Find public, storyline-potential life events not yet used
+    events = db.query(LifeEventDB).filter(
+        LifeEventDB.world_id == world_id,
+        LifeEventDB.is_public == True,
+        LifeEventDB.storyline_potential == True,
+        LifeEventDB.was_used_in_storyline == False,
+        LifeEventDB.is_active == True,
+    ).all()
+
+    for event in events:
+        wrestler = db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.id == event.wrestler_id,
+        ).first()
+        if not wrestler:
+            continue
+
+        # Find the wrestler's federation
+        contract = db.query(ContractDB).filter(
+            ContractDB.wrestler_id == wrestler.id,
+            ContractDB.status == "active",
+        ).first()
+        if not contract:
+            continue
+
+        fed = db.query(GameFederationDB).filter(
+            GameFederationDB.id == contract.federation_id,
+        ).first()
+        if not fed:
+            continue
+
+        # Only low-to-medium kayfabe federations use real events
+        strictness = fed.kayfabe_strictness or 50
+        if strictness > 60:
+            continue
+
+        # Probability based on severity and fed's openness
+        probability = (event.severity / 10.0) * ((100 - strictness) / 100.0) * 0.3
+        if random.random() > probability:
+            continue
+
+        # Find a foil — someone the wrestler has a relationship with
+        rel = db.query(WrestlerRelationshipDB).filter(
+            ((WrestlerRelationshipDB.wrestler1_id == wrestler.id) |
+             (WrestlerRelationshipDB.wrestler2_id == wrestler.id)),
+            WrestlerRelationshipDB.rivalry_heat > 30,
+        ).first()
+
+        if rel:
+            foil_id = rel.wrestler2_id if rel.wrestler1_id == wrestler.id else rel.wrestler1_id
+        else:
+            # Pick a random roster member
+            roster = db.query(ContractDB).filter(
+                ContractDB.federation_id == fed.id,
+                ContractDB.status == "active",
+                ContractDB.wrestler_id != wrestler.id,
+            ).all()
+            if not roster:
+                continue
+            foil_id = random.choice(roster).wrestler_id
+
+        # Determine kayfabe level based on how "real" the source material is
+        kayfabe_level = max(10, 50 - event.severity * 4)
+
+        sl = create_storyline(
+            db, world_id, fed.id,
+            [wrestler.id, foil_id],
+            storyline_type="feud",
+            name=random.choice(WORKED_SHOOT_NAMES),
+            description=random.choice(WORKED_SHOOT_DESCRIPTIONS),
+            game_date=game_date,
+            kayfabe_level=kayfabe_level,
+        )
+        event.was_used_in_storyline = True
+        new_storylines.append(sl)
+        logger.info("Created worked-shoot storyline '%s' from life event for %s",
+                     sl.name, wrestler.name)
+
+    return new_storylines
+
+
+def check_relationship_collision_storylines(db: Session, world_id: str, game_date: str):
+    """Check for real-vs-kayfabe relationship collisions that could become storylines.
+
+    Detects: real friends booked as rivals, real enemies booked as allies.
+    """
+    new_storylines = []
+
+    # Find relationships where real and kayfabe are in tension
+    rels = db.query(WrestlerRelationshipDB).filter(
+        WrestlerRelationshipDB.world_id == world_id,
+    ).all()
+
+    for rel in rels:
+        real = rel.real_relationship
+        kayfabe = rel.kayfabe_alignment
+        if not real or not kayfabe:
+            continue
+
+        # Real friends, kayfabe rivals — potential worked-shoot tension
+        is_collision = (
+            (real == "friends" and kayfabe == "rivals") or
+            (real == "enemies" and kayfabe in ("allies", "tag_partners"))
+        )
+        if not is_collision:
+            continue
+
+        # Low probability per check — this is a slow-burn trigger
+        if random.random() > 0.05:
+            continue
+
+        # Check if they already have an active storyline
+        existing = _find_storyline_between(db, rel.wrestler1_id, rel.wrestler2_id)
+        if existing:
+            continue
+
+        # Find federation
+        contract = db.query(ContractDB).filter(
+            ContractDB.wrestler_id == rel.wrestler1_id,
+            ContractDB.status == "active",
+        ).first()
+        if not contract:
+            continue
+
+        fed = db.query(GameFederationDB).filter(
+            GameFederationDB.id == contract.federation_id,
+        ).first()
+        if not fed or (fed.kayfabe_strictness or 50) > 70:
+            continue
+
+        collision_type = "feud" if real == "enemies" else "betrayal"
+        sl = create_storyline(
+            db, world_id, fed.id,
+            [rel.wrestler1_id, rel.wrestler2_id],
+            storyline_type=collision_type,
+            name=random.choice(WORKED_SHOOT_NAMES),
+            description="The tension between these two has become impossible to contain.",
+            game_date=game_date,
+            kayfabe_level=30,
+        )
+        new_storylines.append(sl)
+
+    return new_storylines

--- a/game_service/world_ticker.py
+++ b/game_service/world_ticker.py
@@ -165,6 +165,9 @@ class WorldTicker:
         # 13. Wrestler lifecycle (Groups 1-6)
         self._wrestler_lifecycle(new_date)
 
+        # 14. Persona & social media (Group 7)
+        self._persona_tick(new_date)
+
         self.db.commit()
 
         return {
@@ -1337,6 +1340,50 @@ class WorldTicker:
                     # Only apply once per return (when they get booked again,
                     # ring_rust_days resets)
                     pass  # Pop applied in match_aftermath when booked
+
+    # ------------------------------------------------------------------
+    # Phase 14: Persona & Social Media (Group 7)
+    # ------------------------------------------------------------------
+
+    def _persona_tick(self, game_date: str):
+        """Persona duality processing: gimmick evolution, life events, social media."""
+        # Weekly persona tick on Fridays
+        if get_day_of_week(game_date) == 4:  # Friday
+            try:
+                from game_service.wrestler_lifecycle_service import tick_persona
+                tick_persona(self.db, self.world.id, game_date)
+                self.events.append("Persona lifecycle tick processed")
+            except Exception as e:
+                logger.warning(f"Persona tick failed: {e}")
+
+            # Check for worked-shoot storylines from life events
+            try:
+                from game_service.storyline_service import (
+                    check_life_event_storylines,
+                    check_relationship_collision_storylines,
+                )
+                ws_storylines = check_life_event_storylines(
+                    self.db, self.world.id, game_date
+                )
+                for sl in ws_storylines:
+                    self.events.append(f"Worked-shoot storyline '{sl.name}' created!")
+
+                coll_storylines = check_relationship_collision_storylines(
+                    self.db, self.world.id, game_date
+                )
+                for sl in coll_storylines:
+                    self.events.append(f"Collision storyline '{sl.name}' created!")
+            except Exception as e:
+                logger.warning(f"Kayfabe collision check failed: {e}")
+
+        # Daily social media tick
+        try:
+            from game_service import social_media_service
+            social_media_service.tick_social_media(
+                self.db, self.world.id, game_date
+            )
+        except Exception as e:
+            logger.warning(f"Social media tick failed: {e}")
 
     # ------------------------------------------------------------------
     # Helpers

--- a/game_service/wrestler_lifecycle_service.py
+++ b/game_service/wrestler_lifecycle_service.py
@@ -18,6 +18,7 @@ from models.game_models import (
     ShowDB, ShowSegmentDB, WrestlerPushDB, BookingVisionDB,
     GameNarrativeLogDB, WrestlerHistoryDB,
     WrestlerGoalDB, MentorshipDB, CareerHighlightDB, HallOfFameDB,
+    GimmickHistoryDB, WrestlerBackstoryDB, LifeEventDB,
 )
 
 logger = logging.getLogger(__name__)
@@ -724,3 +725,63 @@ def grow_specialization(stats: WrestlerStatsDB, stipulation: str):
     if attr:
         old = getattr(stats, attr, 0) or 0
         setattr(stats, attr, min(100, old + 2))
+
+
+# ---------------------------------------------------------------------------
+# Group 7: Persona — Gimmick Evolution & Life Events
+# ---------------------------------------------------------------------------
+
+def tick_persona(db: Session, world_id: str, game_date: str):
+    """Weekly persona tick: gimmick staleness, life events, gimmick evolution.
+
+    Called from world ticker on Fridays.
+    """
+    from game_service import persona_service
+
+    wrestlers = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.world_id == world_id,
+        GameWrestlerDB.is_active == True,
+    ).all()
+
+    for wrestler in wrestlers:
+        # Ensure persona data exists (migration for pre-existing wrestlers)
+        backstory = db.query(WrestlerBackstoryDB).filter(
+            WrestlerBackstoryDB.wrestler_id == wrestler.id,
+        ).first()
+        if not backstory:
+            persona_service.generate_backstory(db, wrestler)
+
+        gimmick = db.query(GimmickHistoryDB).filter(
+            GimmickHistoryDB.wrestler_id == wrestler.id,
+            GimmickHistoryDB.is_active == True,
+        ).first()
+        if not gimmick:
+            persona_service.generate_initial_gimmick(db, wrestler, game_date)
+            continue
+
+        # Tick gimmick staleness
+        persona_service.tick_gimmick_staleness(db, wrestler, game_date)
+
+        # Evolve gimmick depth/fan investment based on recent activity
+        persona_service.evolve_gimmick(db, wrestler, game_date)
+
+        # Check for repackaging pressure (NPC only)
+        if wrestler.is_npc:
+            pressure = persona_service.check_repackaging_pressure(db, wrestler)
+            if pressure["pressure"] > 80:
+                persona_service.execute_gimmick_change(
+                    db, wrestler, game_date, pressure["reason"]
+                )
+
+        # Life event roll (~3% per wrestler per week)
+        persona_service.generate_life_event(db, wrestler.id, world_id, game_date)
+
+        # Process effects of active life events
+        active_events = db.query(LifeEventDB).filter(
+            LifeEventDB.wrestler_id == wrestler.id,
+            LifeEventDB.is_active == True,
+        ).all()
+        for event in active_events:
+            persona_service.process_life_event_effects(db, event)
+
+    db.flush()

--- a/models/game_models.py
+++ b/models/game_models.py
@@ -252,6 +252,10 @@ class GameFederationDB(Base):
     regional_strength = Column(JSON, default=dict)  # {region: 0-100} strength per market
     is_active = Column(Boolean, default=True)
     ai_personality = Column(JSON, default=dict)  # LLM personality traits for NPC booking
+    # --- Kayfabe Profile ---
+    kayfabe_strictness = Column(Integer, default=50)  # 0-100, how strictly kayfabe is enforced
+    allows_worked_shoots = Column(Boolean, default=True)  # Whether worked shoots are permitted
+    social_media_policy = Column(String(20), default="guided")  # strict_kayfabe, guided, free
     created_at = Column(DateTime, default=_utc_now)
     updated_at = Column(DateTime, default=_utc_now, onupdate=_utc_now)
 
@@ -327,6 +331,14 @@ class GameWrestlerDB(Base):
     created_at = Column(DateTime, default=_utc_now)
     updated_at = Column(DateTime, default=_utc_now, onupdate=_utc_now)
 
+    # --- Persona & Gimmick ---
+    kayfabe_commitment = Column(Integer, default=50)  # 0-100, how seriously they protect kayfabe
+    social_media_following = Column(Integer, default=1000)  # Fan base size
+    public_perception = Column(String(30), default="neutral")  # beloved, respected, controversial, forgotten, neutral
+    character_depth = Column(Integer, default=40)  # 0-100, how developed their character work is
+    gimmick_changes = Column(Integer, default=0)  # How many times repackaged
+    kayfabe_break_count = Column(Integer, default=0)  # Times the person broke character publicly
+
     world = relationship("WorldDB", back_populates="wrestlers")
     player = relationship("PlayerDB", back_populates="wrestler",
                           foreign_keys="PlayerDB.wrestler_id", uselist=False)
@@ -339,6 +351,15 @@ class GameWrestlerDB(Base):
     storyline_roles = relationship("StorylineParticipantDB", back_populates="wrestler")
     title_reigns = relationship("ChampionshipHistoryDB", back_populates="wrestler")
     history_entries = relationship("WrestlerHistoryDB", back_populates="wrestler")
+    backstory = relationship("WrestlerBackstoryDB", back_populates="wrestler",
+                             uselist=False, cascade="all, delete-orphan")
+    gimmick_history = relationship("GimmickHistoryDB", back_populates="wrestler",
+                                   cascade="all, delete-orphan")
+    life_events = relationship("LifeEventDB", back_populates="wrestler",
+                               cascade="all, delete-orphan")
+    social_media_posts = relationship("SocialMediaPostDB", back_populates="wrestler",
+                                      foreign_keys="SocialMediaPostDB.wrestler_id",
+                                      cascade="all, delete-orphan")
 
 
 class WrestlerStatsDB(Base):
@@ -618,6 +639,7 @@ class StorylineDB(Base):
     end_date = Column(String(10), nullable=True)
     planned_blowoff = Column(Text, nullable=True)  # Planned conclusion
     ai_notes = Column(JSON, default=dict)  # LLM context for continuing the story
+    kayfabe_level = Column(Integer, default=100)  # 100=pure fiction, 0=shoot; for worked-shoot storylines
     created_at = Column(DateTime, default=_utc_now)
     updated_at = Column(DateTime, default=_utc_now, onupdate=_utc_now)
 
@@ -739,6 +761,11 @@ class WrestlerRelationshipDB(Base):
     chemistry_score = Column(Float, default=0.0)  # Computed: total_rating / matches_together
     rivalry_heat = Column(Integer, default=0)  # 0-100, intensity of rivalry
     last_match_date = Column(String(10), nullable=True)
+    # --- Real vs Kayfabe relationship layers ---
+    relationship_type = Column(String(20), default="professional")  # professional, personal, romantic, family, mentorship
+    kayfabe_alignment = Column(String(20), nullable=True)  # allies, rivals, tag_partners, neutral (on-screen)
+    real_relationship = Column(String(20), nullable=True)  # friends, enemies, indifferent, romantic (backstage)
+    trust_level = Column(Integer, default=50)  # 0-100, real interpersonal trust
     updated_at = Column(DateTime, default=_utc_now, onupdate=_utc_now)
 
     __table_args__ = (
@@ -983,4 +1010,138 @@ class HallOfFameDB(Base):
 
     __table_args__ = (
         UniqueConstraint("world_id", "wrestler_id", name="uq_hof_wrestler"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persona Duality: The Human Behind the Character
+# ---------------------------------------------------------------------------
+
+class WrestlerBackstoryDB(Base):
+    """The real person behind the wrestling character."""
+    __tablename__ = "wrestler_backstories"
+
+    id = Column(String, primary_key=True, default=_uuid)
+    wrestler_id = Column(String, ForeignKey("game_wrestlers.id"), nullable=False, unique=True)
+    origin_story = Column(Text, nullable=True)  # Narrative of where they came from
+    family_situation = Column(String(50), default="single")  # single, married, divorced, kids, estranged
+    pre_wrestling_career = Column(String(100), nullable=True)  # Bouncer, teacher, athlete, military
+    wrestling_motivation = Column(String(50), default="passion")  # passion, money, legacy, escape, family_tradition
+    real_personality = Column(JSON, default=dict)
+    # Structure: {
+    #   "temperament": "calm"|"volatile"|"anxious"|"steady",
+    #   "introversion": 0-100 (0=extrovert, 100=introvert),
+    #   "ambition": 0-100,
+    #   "ego": 0-100,
+    #   "substance_risk": 0-100,
+    #   "media_savvy": 0-100,
+    # }
+    personal_struggles = Column(JSON, default=list)  # ["financial_pressure", "family_estrangement"]
+    personal_life_stability = Column(Integer, default=70)  # 0-100 aggregate health of real life
+    created_at = Column(DateTime, default=_utc_now)
+    updated_at = Column(DateTime, default=_utc_now, onupdate=_utc_now)
+
+    wrestler = relationship("GameWrestlerDB", back_populates="backstory")
+
+
+class GimmickHistoryDB(Base):
+    """A wrestling gimmick/character that a wrestler has adopted.
+
+    Wrestlers can have multiple gimmicks over their career (1-to-many).
+    Exactly one should have is_active=True at any time.
+    """
+    __tablename__ = "gimmick_history"
+
+    id = Column(String, primary_key=True, default=_uuid)
+    wrestler_id = Column(String, ForeignKey("game_wrestlers.id"), nullable=False, index=True)
+    gimmick_name = Column(String(100), nullable=False)  # Ring name / character name
+    archetype = Column(String(30), default="anti_hero")
+    # Archetypes: monster_heel, underdog_face, cocky_technician, silent_assassin,
+    #             cult_leader, comedy_act, anti_hero, legacy, patriot, daredevil
+    description = Column(Text, nullable=True)  # Full character description
+    origin_narrative = Column(Text, nullable=True)  # Kayfabe origin story
+    alignment = Column(String(20), default="face")  # Alignment during this gimmick
+    voice_style = Column(JSON, default=dict)
+    # Structure: {
+    #   "vocabulary": "simple"|"elaborate"|"street"|"academic",
+    #   "cadence": "rapid_fire"|"slow_burn"|"staccato"|"conversational",
+    #   "catchphrases": ["..."],
+    #   "speech_patterns": ["third_person", "yelling", "whispering", "monotone"],
+    #   "promo_tempo": "aggressive"|"methodical"|"erratic"|"cool",
+    # }
+    visual_identity = Column(JSON, default=dict)  # attire, mask, face_paint, signature_look
+    start_date = Column(String(10), nullable=True)  # Game date adopted
+    end_date = Column(String(10), nullable=True)  # Game date retired (null = current)
+    depth_score = Column(Integer, default=40)  # 0-100, how layered/developed
+    effectiveness = Column(Integer, default=50)  # 0-100, how well it's working with audiences
+    staleness = Column(Integer, default=0)  # 0-100, increases over time
+    fan_investment = Column(Integer, default=30)  # 0-100, emotional attachment
+    is_active = Column(Boolean, default=True)
+    reason_for_change = Column(Text, nullable=True)  # Why they changed (for retired gimmicks)
+    created_at = Column(DateTime, default=_utc_now)
+
+    wrestler = relationship("GameWrestlerDB", back_populates="gimmick_history")
+
+
+class LifeEventDB(Base):
+    """A real-life event affecting the person behind the wrestler.
+
+    These events can affect morale, performance, and potentially become
+    storyline material depending on federation kayfabe strictness.
+    """
+    __tablename__ = "life_events"
+
+    id = Column(String, primary_key=True, default=_uuid)
+    wrestler_id = Column(String, ForeignKey("game_wrestlers.id"), nullable=False, index=True)
+    world_id = Column(String, ForeignKey("worlds.id"), nullable=False, index=True)
+    game_date = Column(String(10), nullable=False)
+    event_type = Column(String(30), nullable=False)
+    # Types: marriage, divorce, child_born, death_in_family, legal_trouble,
+    #        personal_achievement, substance_issue, public_controversy,
+    #        charity_work, outside_media, financial_trouble, mental_health,
+    #        relationship_start, relationship_end, family_reconciliation
+    description = Column(Text, nullable=False)
+    severity = Column(Integer, default=5)  # 1-10 impact magnitude
+    is_public = Column(Boolean, default=False)  # Known to fans/media?
+    morale_impact = Column(Integer, default=0)  # Delta to wrestler morale
+    performance_impact = Column(Integer, default=0)  # Delta to in-ring work quality
+    storyline_potential = Column(Boolean, default=False)  # Could become a storyline?
+    was_used_in_storyline = Column(Boolean, default=False)
+    is_active = Column(Boolean, default=True)  # Ongoing vs resolved
+    resolved_date = Column(String(10), nullable=True)
+    created_at = Column(DateTime, default=_utc_now)
+
+    wrestler = relationship("GameWrestlerDB", back_populates="life_events")
+
+    __table_args__ = (
+        Index("ix_life_event_world_date", "world_id", "game_date"),
+    )
+
+
+class SocialMediaPostDB(Base):
+    """A social media post by a wrestler — in-character, shoot, or ambiguous."""
+    __tablename__ = "social_media_posts"
+
+    id = Column(String, primary_key=True, default=_uuid)
+    wrestler_id = Column(String, ForeignKey("game_wrestlers.id"), nullable=False, index=True)
+    world_id = Column(String, ForeignKey("worlds.id"), nullable=False, index=True)
+    game_date = Column(String(10), nullable=False)
+    content = Column(Text, nullable=False)  # The post text
+    post_type = Column(String(20), default="kayfabe")  # kayfabe, shoot, worked_shoot, personal
+    platform = Column(String(20), default="twitter")  # twitter, instagram, youtube, tiktok, podcast
+    engagement_score = Column(Integer, default=10)  # 0-100 virality/interaction
+    controversy_level = Column(Integer, default=0)  # 0-100 heat generated
+    storyline_id = Column(String, ForeignKey("storylines.id"), nullable=True)
+    target_wrestler_id = Column(String, ForeignKey("game_wrestlers.id"), nullable=True)
+    is_viral = Column(Boolean, default=False)
+    fan_reaction = Column(String(20), default="positive")  # positive, negative, mixed, confused
+    kayfabe_break_level = Column(Integer, default=0)  # 0-100, how much fourth wall is broken
+    popularity_impact = Column(Integer, default=0)  # Delta to wrestler popularity
+    created_at = Column(DateTime, default=_utc_now)
+
+    wrestler = relationship("GameWrestlerDB", back_populates="social_media_posts",
+                            foreign_keys=[wrestler_id])
+
+    __table_args__ = (
+        Index("ix_social_media_world_date", "world_id", "game_date"),
     )

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -1,0 +1,530 @@
+"""
+Tests for the wrestler persona duality system.
+
+Covers: backstory generation, gimmick creation/evolution, life events,
+social media posts, persona-aware promos, kayfabe collision detection.
+"""
+
+import pytest
+import random
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+# We test with in-memory SQLite
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.db_models import Base
+from models.game_models import (
+    GameWrestlerDB, WrestlerStatsDB, WrestlerBackstoryDB,
+    GimmickHistoryDB, LifeEventDB, SocialMediaPostDB,
+    WrestlerRelationshipDB, GameFederationDB, ContractDB,
+    WorldDB, StorylineDB, StorylineParticipantDB, PromoDB,
+    WorldNewsDB,
+)
+
+
+@pytest.fixture
+def db_session():
+    """Create a fresh in-memory database for each test."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def world(db_session):
+    """Create a test world."""
+    w = WorldDB(
+        id="world1",
+        name="Test World",
+        current_game_date="2026-03-01",
+        current_tick=1,
+    )
+    db_session.add(w)
+    db_session.flush()
+    return w
+
+
+@pytest.fixture
+def federation(db_session, world):
+    """Create a test federation."""
+    fed = GameFederationDB(
+        id="fed1",
+        world_id=world.id,
+        name="Test Wrestling Federation",
+        short_name="TWF",
+        kayfabe_strictness=50,
+        allows_worked_shoots=True,
+        social_media_policy="guided",
+    )
+    db_session.add(fed)
+    db_session.flush()
+    return fed
+
+
+@pytest.fixture
+def wrestler(db_session, world):
+    """Create a test wrestler."""
+    w = GameWrestlerDB(
+        id="w1",
+        world_id=world.id,
+        name="Thunder McSlam",
+        real_name="John Smith",
+        gimmick="A powerhouse brawler",
+        alignment="face",
+        popularity=60,
+        morale=70,
+        age=28,
+        hometown="Dallas, TX",
+        catchphrase="Feel the thunder!",
+        finisher_name="Thunder Driver",
+        finisher_type="power",
+        personality_traits={"aggression": 70, "charisma_style": "intense"},
+        kayfabe_commitment=60,
+        character_depth=40,
+    )
+    db_session.add(w)
+    stats = WrestlerStatsDB(
+        wrestler_id=w.id,
+        power=75, speed=50, technical=40, aerial=30,
+        brawling=80, submission=30, stamina=70, toughness=75,
+        charisma=65, mic_skill=55, psychology=50, selling=45,
+    )
+    db_session.add(stats)
+    db_session.flush()
+    return w
+
+
+@pytest.fixture
+def wrestler2(db_session, world):
+    """Create a second test wrestler."""
+    w = GameWrestlerDB(
+        id="w2",
+        world_id=world.id,
+        name="Dark Phantom",
+        real_name="Mike Jones",
+        gimmick="A mysterious heel",
+        alignment="heel",
+        popularity=55,
+        morale=65,
+        age=30,
+        hometown="Chicago, IL",
+        kayfabe_commitment=80,
+        character_depth=50,
+    )
+    db_session.add(w)
+    stats = WrestlerStatsDB(
+        wrestler_id=w.id,
+        power=60, speed=65, technical=70, aerial=40,
+        brawling=50, submission=60, stamina=65, toughness=60,
+        charisma=70, mic_skill=75, psychology=65, selling=60,
+    )
+    db_session.add(stats)
+    db_session.flush()
+    return w
+
+
+# ===================================================================
+# Backstory tests
+# ===================================================================
+
+class TestBackstoryGeneration:
+    def test_generate_backstory(self, db_session, wrestler):
+        from game_service.persona_service import generate_backstory
+        backstory = generate_backstory(db_session, wrestler)
+
+        assert backstory is not None
+        assert backstory.wrestler_id == wrestler.id
+        assert backstory.origin_story is not None
+        assert len(backstory.origin_story) > 10
+        assert backstory.family_situation in [
+            "single", "married", "married_with_kids", "divorced",
+            "divorced_with_kids", "long_term_relationship",
+            "estranged_family", "close_family",
+        ]
+        assert backstory.wrestling_motivation is not None
+        assert backstory.real_personality is not None
+        assert "temperament" in backstory.real_personality
+        assert "ambition" in backstory.real_personality
+        assert 0 <= backstory.personal_life_stability <= 100
+
+    def test_backstory_persists(self, db_session, wrestler):
+        from game_service.persona_service import generate_backstory
+        generate_backstory(db_session, wrestler)
+        db_session.flush()
+
+        loaded = db_session.query(WrestlerBackstoryDB).filter(
+            WrestlerBackstoryDB.wrestler_id == wrestler.id,
+        ).first()
+        assert loaded is not None
+        assert loaded.origin_story is not None
+
+
+# ===================================================================
+# Gimmick tests
+# ===================================================================
+
+class TestGimmickGeneration:
+    def test_generate_initial_gimmick(self, db_session, wrestler):
+        from game_service.persona_service import generate_initial_gimmick
+        gimmick = generate_initial_gimmick(db_session, wrestler, "2026-03-01")
+
+        assert gimmick is not None
+        assert gimmick.wrestler_id == wrestler.id
+        assert gimmick.is_active is True
+        assert gimmick.archetype in [
+            "monster_heel", "underdog_face", "cocky_technician",
+            "silent_assassin", "cult_leader", "comedy_act",
+            "anti_hero", "legacy", "patriot", "daredevil",
+        ]
+        assert gimmick.staleness == 0
+        assert gimmick.depth_score > 0
+        assert gimmick.voice_style is not None
+
+    def test_gimmick_staleness_increases(self, db_session, wrestler):
+        from game_service.persona_service import (
+            generate_initial_gimmick, tick_gimmick_staleness,
+        )
+        gimmick = generate_initial_gimmick(db_session, wrestler, "2026-03-01")
+        initial_staleness = gimmick.staleness
+
+        tick_gimmick_staleness(db_session, wrestler, "2026-03-08")
+        assert gimmick.staleness >= initial_staleness
+
+    def test_repackaging_pressure(self, db_session, wrestler):
+        from game_service.persona_service import (
+            generate_initial_gimmick, check_repackaging_pressure,
+        )
+        gimmick = generate_initial_gimmick(db_session, wrestler, "2026-03-01")
+        gimmick.staleness = 80
+        gimmick.effectiveness = 20
+        gimmick.fan_investment = 10
+
+        pressure = check_repackaging_pressure(db_session, wrestler)
+        assert pressure["pressure"] >= 60
+        assert pressure["reason"] != "none"
+
+    def test_execute_gimmick_change(self, db_session, wrestler):
+        from game_service.persona_service import (
+            generate_initial_gimmick, execute_gimmick_change,
+        )
+        old_gimmick = generate_initial_gimmick(db_session, wrestler, "2026-03-01")
+        old_archetype = old_gimmick.archetype
+
+        new_gimmick = execute_gimmick_change(
+            db_session, wrestler, "2026-06-01", "stale_gimmick",
+        )
+
+        assert old_gimmick.is_active is False
+        assert old_gimmick.end_date == "2026-06-01"
+        assert new_gimmick.is_active is True
+        assert new_gimmick.archetype != old_archetype
+        assert new_gimmick.staleness == 0
+        assert wrestler.gimmick_changes >= 1
+
+    def test_evolve_gimmick_depth(self, db_session, wrestler):
+        from game_service.persona_service import (
+            generate_initial_gimmick, evolve_gimmick,
+        )
+        gimmick = generate_initial_gimmick(db_session, wrestler, "2026-03-01")
+        initial_depth = gimmick.depth_score
+
+        wrestler.last_booked_date = "2026-03-08"
+        evolve_gimmick(db_session, wrestler, "2026-03-08")
+        assert gimmick.depth_score >= initial_depth
+
+
+# ===================================================================
+# Life event tests
+# ===================================================================
+
+class TestLifeEvents:
+    def test_generate_life_event_low_probability(self, db_session, wrestler, world):
+        from game_service.persona_service import generate_backstory, generate_life_event
+        generate_backstory(db_session, wrestler)
+
+        # With 3% chance, most calls return None
+        results = [
+            generate_life_event(db_session, wrestler.id, world.id, "2026-03-01")
+            for _ in range(20)
+        ]
+        none_count = sum(1 for r in results if r is None)
+        assert none_count > 10  # Most should be None
+
+    def test_generate_life_event_forced(self, db_session, wrestler, world):
+        from game_service.persona_service import generate_backstory
+        generate_backstory(db_session, wrestler)
+
+        # Directly seed a life event
+        event = LifeEventDB(
+            wrestler_id=wrestler.id,
+            world_id=world.id,
+            game_date="2026-03-01",
+            event_type="marriage",
+            description="Thunder McSlam got married.",
+            severity=4,
+            is_public=True,
+            morale_impact=15,
+            performance_impact=0,
+            storyline_potential=False,
+        )
+        db_session.add(event)
+        db_session.flush()
+
+        loaded = db_session.query(LifeEventDB).filter(
+            LifeEventDB.wrestler_id == wrestler.id,
+        ).first()
+        assert loaded is not None
+        assert loaded.event_type == "marriage"
+
+    def test_process_life_event_effects(self, db_session, wrestler, world):
+        from game_service.persona_service import (
+            generate_backstory, process_life_event_effects,
+        )
+        generate_backstory(db_session, wrestler)
+        initial_morale = wrestler.morale
+
+        event = LifeEventDB(
+            wrestler_id=wrestler.id,
+            world_id=world.id,
+            game_date="2026-03-01",
+            event_type="death_in_family",
+            description="Lost a family member.",
+            severity=9,
+            morale_impact=-25,
+            performance_impact=-10,
+            is_active=True,
+        )
+        db_session.add(event)
+        db_session.flush()
+
+        process_life_event_effects(db_session, event)
+        assert wrestler.morale < initial_morale
+
+
+# ===================================================================
+# Social media tests
+# ===================================================================
+
+class TestSocialMedia:
+    def test_generate_social_post(self, db_session, wrestler, world):
+        from game_service.social_media_service import generate_social_post
+        post = generate_social_post(db_session, wrestler.id, world.id, "2026-03-01")
+
+        assert post is not None
+        assert post.wrestler_id == wrestler.id
+        assert post.content is not None
+        assert len(post.content) > 0
+        assert post.post_type in ["kayfabe", "shoot", "worked_shoot", "personal"]
+        assert post.platform in ["twitter", "instagram", "tiktok", "youtube"]
+        assert 0 <= post.engagement_score <= 100
+
+    def test_feud_exchange(self, db_session, wrestler, wrestler2, world):
+        from game_service.social_media_service import generate_feud_exchange
+        posts = generate_feud_exchange(
+            db_session, wrestler.id, wrestler2.id, world.id, "2026-03-01",
+        )
+
+        assert len(posts) == 2
+        assert posts[0].wrestler_id == wrestler.id
+        assert posts[1].wrestler_id == wrestler2.id
+        assert posts[0].target_wrestler_id == wrestler2.id
+        assert posts[1].target_wrestler_id == wrestler.id
+
+    def test_viral_moment_detection(self):
+        from game_service.social_media_service import check_viral_moment
+        # High-controversy post should have higher viral chance
+        post = MagicMock()
+        post.controversy_level = 80
+        post.engagement_score = 90
+        post.post_type = "worked_shoot"
+        post.kayfabe_break_level = 70
+
+        # Run many times — should go viral at least once
+        random.seed(42)
+        results = [check_viral_moment(post) for _ in range(100)]
+        assert any(results)
+
+
+# ===================================================================
+# Persona-aware promo tests
+# ===================================================================
+
+class TestPersonaPromos:
+    def test_promo_with_gimmick(self, db_session, wrestler, world):
+        from game_service.persona_service import generate_initial_gimmick
+        from game_service.promo_service import generate_promo
+
+        generate_initial_gimmick(db_session, wrestler, "2026-03-01")
+        promo = generate_promo(
+            db_session, world.id, wrestler.id,
+            game_date="2026-03-01",
+        )
+
+        assert promo is not None
+        assert promo.content is not None
+        assert len(promo.content) > 10
+        assert promo.quality_rating >= 0.5
+
+    def test_promo_falls_back_without_gimmick(self, db_session, wrestler, world):
+        from game_service.promo_service import generate_promo
+        # No gimmick data — should use legacy templates
+        promo = generate_promo(
+            db_session, world.id, wrestler.id,
+            game_date="2026-03-01",
+        )
+
+        assert promo is not None
+        assert promo.content is not None
+
+    def test_promo_with_target(self, db_session, wrestler, wrestler2, world):
+        from game_service.persona_service import generate_initial_gimmick
+        from game_service.promo_service import generate_promo
+
+        generate_initial_gimmick(db_session, wrestler, "2026-03-01")
+        promo = generate_promo(
+            db_session, world.id, wrestler.id,
+            target_wrestler_id=wrestler2.id,
+            game_date="2026-03-01",
+        )
+
+        assert promo is not None
+        assert promo.target_wrestler_id == wrestler2.id
+
+    def test_promo_quality_improved_by_gimmick_depth(self, db_session, wrestler, world):
+        from game_service.persona_service import generate_initial_gimmick
+        from game_service.promo_service import generate_promo
+
+        gimmick = generate_initial_gimmick(db_session, wrestler, "2026-03-01")
+        gimmick.depth_score = 90
+        gimmick.effectiveness = 85
+
+        # Generate many promos and check average quality
+        random.seed(42)
+        qualities = []
+        for _ in range(20):
+            promo = generate_promo(
+                db_session, world.id, wrestler.id,
+                game_date="2026-03-01",
+            )
+            qualities.append(promo.quality_rating)
+
+        avg_quality = sum(qualities) / len(qualities)
+        assert avg_quality > 2.0  # Should be above average with deep gimmick
+
+
+# ===================================================================
+# Collision detection tests
+# ===================================================================
+
+class TestCollisionDetection:
+    def test_crisis_during_push(self, db_session, wrestler, world):
+        from game_service.persona_service import (
+            generate_backstory, detect_collision_events,
+        )
+        generate_backstory(db_session, wrestler)
+        wrestler.popularity = 80
+
+        event = LifeEventDB(
+            wrestler_id=wrestler.id, world_id=world.id,
+            game_date="2026-03-01", event_type="death_in_family",
+            description="Lost family member", severity=9,
+            is_active=True, morale_impact=-25, performance_impact=-10,
+        )
+        db_session.add(event)
+        db_session.flush()
+
+        collisions = detect_collision_events(db_session, wrestler, "2026-03-01")
+        types = [c["type"] for c in collisions]
+        assert "crisis_during_push" in types
+
+    def test_friends_as_rivals(self, db_session, wrestler, wrestler2, world):
+        from game_service.persona_service import detect_collision_events
+
+        rel = WrestlerRelationshipDB(
+            world_id=world.id,
+            wrestler1_id=wrestler.id,
+            wrestler2_id=wrestler2.id,
+            real_relationship="friends",
+            kayfabe_alignment="rivals",
+        )
+        db_session.add(rel)
+        db_session.flush()
+
+        collisions = detect_collision_events(db_session, wrestler, "2026-03-01")
+        types = [c["type"] for c in collisions]
+        assert "friends_as_rivals" in types
+
+    def test_facade_cracking(self, db_session, wrestler, world):
+        from game_service.persona_service import (
+            generate_backstory, detect_collision_events,
+        )
+        backstory = generate_backstory(db_session, wrestler)
+        backstory.personal_life_stability = 20
+        wrestler.kayfabe_commitment = 85
+
+        collisions = detect_collision_events(db_session, wrestler, "2026-03-01")
+        types = [c["type"] for c in collisions]
+        assert "facade_cracking" in types
+
+
+# ===================================================================
+# Migration tests
+# ===================================================================
+
+class TestMigration:
+    def test_migrate_existing_wrestlers(self, db_session, wrestler, world):
+        from game_service.persona_service import migrate_existing_wrestlers
+
+        count = migrate_existing_wrestlers(db_session, world.id)
+        assert count >= 1
+
+        backstory = db_session.query(WrestlerBackstoryDB).filter(
+            WrestlerBackstoryDB.wrestler_id == wrestler.id,
+        ).first()
+        assert backstory is not None
+
+        gimmick = db_session.query(GimmickHistoryDB).filter(
+            GimmickHistoryDB.wrestler_id == wrestler.id,
+            GimmickHistoryDB.is_active == True,
+        ).first()
+        assert gimmick is not None
+
+    def test_migrate_is_idempotent(self, db_session, wrestler, world):
+        from game_service.persona_service import migrate_existing_wrestlers
+
+        count1 = migrate_existing_wrestlers(db_session, world.id)
+        count2 = migrate_existing_wrestlers(db_session, world.id)
+        assert count2 == 0  # Already migrated
+
+
+# ===================================================================
+# Kayfabe storyline tests
+# ===================================================================
+
+class TestKayfabeSpectrum:
+    def test_create_storyline_with_kayfabe_level(self, db_session, world, federation, wrestler, wrestler2):
+        from game_service.storyline_service import create_storyline
+
+        sl = create_storyline(
+            db_session, world.id, federation.id,
+            [wrestler.id, wrestler2.id],
+            storyline_type="feud",
+            game_date="2026-03-01",
+            kayfabe_level=30,
+        )
+        assert sl.kayfabe_level == 30
+
+    def test_default_kayfabe_level(self, db_session, world, federation, wrestler, wrestler2):
+        from game_service.storyline_service import create_storyline
+
+        sl = create_storyline(
+            db_session, world.id, federation.id,
+            [wrestler.id, wrestler2.id],
+            game_date="2026-03-01",
+        )
+        assert sl.kayfabe_level == 100  # Default pure kayfabe


### PR DESCRIPTION
## Summary

They were people before they were wrestlers. This PR models that duality — the real person vs. the performed character, and all the places those two lives intersect, compete, and collide.

- **Analysis document** — deep exploration of persona duality: origin stories, gimmick archetypes, kayfabe spectrum, social media as new arena, collision points between real life and performance
- **4 new DB tables** — `wrestler_backstories`, `gimmick_history`, `life_events`, `social_media_posts`
- **Extended 4 existing tables** — GameWrestlerDB, GameFederationDB, StorylineDB, WrestlerRelationshipDB with kayfabe/persona fields
- **New `persona_service.py`** — backstory generation, gimmick creation/evolution/repackaging, life events engine, collision detection (real friends as kayfabe rivals, crisis during push, facade cracking)
- **New `social_media_service.py`** — daily social tick, post generation by persona type (kayfabe/shoot/worked-shoot/personal), viral moments, feud exchanges
- **Enhanced `promo_service.py`** — 10 archetype voice styles (monster heel, underdog face, cocky technician, silent assassin, cult leader, comedy act, anti-hero, legacy, patriot, daredevil), emotional bleed from life events, worked-shoot promos
- **Enhanced `storyline_service.py`** — kayfabe spectrum (kayfabe_level 0-100), worked-shoot storylines from life events, relationship collision storylines
- **Enhanced `world_ticker.py`** — Phase 14 persona/social media daily tick
- **Enhanced `news_service.py`** — viral social media news, life event news, gimmick change news
- **24 tests passing** covering all persona systems

## Test plan
- [x] 24 new tests pass (`pytest tests/test_persona.py`)
- [x] All model and service imports verified
- [ ] Manual: create world, advance 30+ days, verify persona data populates
- [ ] Manual: verify promos vary by archetype
- [ ] Manual: verify social media posts appear in news feed

https://claude.ai/code/session_016VdqBuSdqAmBxvdavsfJzq