### PR TITLE
fix: Year simulation audit — 7 critical fixes for simulation realism

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_tag_team_finisher_name.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_tag_team_finisher_name.py
@@ -1,0 +1,26 @@
+"""Add tag team finisher name column
+
+Revision ID: a1b2c3d4e5f6
+Revises: 1706a93ccd41
+Create Date: 2026-04-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = '1706a93ccd41'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('tag_teams', sa.Column('team_finisher_name', sa.String(100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('tag_teams', 'team_finisher_name')

--- a/core_engine/match_aftermath.py
+++ b/core_engine/match_aftermath.py
@@ -65,6 +65,12 @@ def process_match_aftermath(db: Session, match: MatchDB, game_date: str):
     # 9. Career highlights (Group 5) and specialization growth (Group 6)
     _post_match_lifecycle(db, match, participants, game_date)
 
+    # 10. Botch consequences — trust degradation, injury, history entries
+    _process_botch_consequences(db, match, game_date)
+
+    # 11. Going-into-business consequences — discipline, locker room heat, trust destruction
+    _process_shoot_consequences(db, match, game_date)
+
 
 def _handle_title_result(db: Session, match: MatchDB,
                          winners: list, losers: list, game_date: str):
@@ -458,3 +464,239 @@ def compute_win_loss(db: Session, wrestler_id: str) -> dict:
 
     losses = total - wins - draws
     return {"wins": wins, "losses": losses, "draws": draws}
+
+
+# ---------------------------------------------------------------------------
+# Botch consequences
+# ---------------------------------------------------------------------------
+
+def _process_botch_consequences(db: Session, match: MatchDB, game_date: str):
+    """Handle the aftermath of botched moves.
+
+    Dangerous botches (severity 3):
+    - Victim may be injured
+    - Trust between wrestlers degrades
+    - History entry recorded for both wrestlers (memory for character agent)
+    - Locker room standing drops for the botcher
+
+    Bad botches (severity 2):
+    - Minor trust degradation
+    - History entry for the botcher
+    """
+    # The match result's botch_events are stored in simulation_log
+    sim_log = match.simulation_log or []
+    botch_events = [s for s in sim_log if s.get("is_botch")]
+    if not botch_events:
+        return
+
+    for botch in botch_events:
+        severity = botch.get("botch_severity", 0)
+        if severity < 2:
+            continue  # Minor stumbles don't have lasting consequences
+
+        attacker_id = botch.get("attacker")
+        victim_id = botch.get("defender")
+        move_name = botch.get("move", "unknown move")
+
+        attacker = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == attacker_id).first()
+        victim = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == victim_id).first()
+        if not attacker or not victim:
+            continue
+
+        # --- Trust degradation between these wrestlers ---
+        rel = db.query(WrestlerRelationshipDB).filter(
+            WrestlerRelationshipDB.world_id == match.world_id,
+            WrestlerRelationshipDB.wrestler1_id.in_([attacker_id, victim_id]),
+            WrestlerRelationshipDB.wrestler2_id.in_([attacker_id, victim_id]),
+        ).first()
+        if rel:
+            trust_drop = 5 if severity == 2 else 15  # Dangerous botch = big trust hit
+            rel.trust_level = max(0, (rel.trust_level or 50) - trust_drop)
+            logger.info("Trust between %s and %s dropped by %d to %d (botch on %s)",
+                        attacker.name, victim.name, trust_drop, rel.trust_level, move_name)
+
+        # --- History entries: both wrestlers remember ---
+        if severity >= 3:
+            # Dangerous botch — victim remembers being hurt
+            db.add(WrestlerHistoryDB(
+                wrestler_id=victim_id,
+                game_date=game_date,
+                event_type="botch_victim",
+                description=f"Was hurt by a botched {move_name} from {attacker.name}",
+                details={"caused_by": attacker_id, "caused_by_name": attacker.name,
+                         "move": move_name, "severity": severity, "match_id": match.id},
+            ))
+            # Attacker remembers hurting someone
+            db.add(WrestlerHistoryDB(
+                wrestler_id=attacker_id,
+                game_date=game_date,
+                event_type="botch_perpetrator",
+                description=f"Botched {move_name} and hurt {victim.name}",
+                details={"victim": victim_id, "victim_name": victim.name,
+                         "move": move_name, "severity": severity, "match_id": match.id},
+            ))
+
+            # Injury check from dangerous botch
+            stats = db.query(WrestlerStatsDB).filter(
+                WrestlerStatsDB.wrestler_id == victim_id
+            ).first()
+            injury_risk = 0.25 + (stats.injury_prone if stats else 30) / 200
+            if random.random() < injury_risk:
+                weeks_out = random.randint(1, 8)
+                from game_service.world_ticker import advance_game_date
+                victim.is_injured = True
+                victim.injury_return_date = advance_game_date(game_date, weeks_out * 7)
+                victim.condition = max(0, victim.condition - random.randint(15, 35))
+
+                db.add(GameNarrativeLogDB(
+                    world_id=match.world_id,
+                    game_date=game_date, tick=0,
+                    event_type="botch_injury",
+                    description=f"{victim.name} injured by botched {move_name} from {attacker.name}! Out {weeks_out} weeks.",
+                    involved_entities=[victim_id, attacker_id],
+                    importance=8,
+                ))
+                logger.info("BOTCH INJURY: %s hurt by %s's %s, out %d weeks",
+                            victim.name, attacker.name, move_name, weeks_out)
+
+            # Locker room standing drops for the botcher
+            if attacker.locker_room_standing in ("leader", "respected"):
+                attacker.locker_room_standing = "neutral"
+            elif attacker.locker_room_standing == "neutral":
+                attacker.locker_room_standing = "disliked"
+
+        elif severity == 2:
+            # Bad botch — attacker remembers
+            db.add(WrestlerHistoryDB(
+                wrestler_id=attacker_id,
+                game_date=game_date,
+                event_type="botch_perpetrator",
+                description=f"Botched {move_name} against {victim.name}",
+                details={"victim": victim_id, "victim_name": victim.name,
+                         "move": move_name, "severity": severity, "match_id": match.id},
+            ))
+
+
+# ---------------------------------------------------------------------------
+# Going-into-business consequences
+# ---------------------------------------------------------------------------
+
+def _process_shoot_consequences(db: Session, match: MatchDB, game_date: str):
+    """Handle consequences when a wrestler goes into business for themselves.
+
+    This is the nuclear option — a wrestler refused to do the planned job.
+    Consequences are severe and long-lasting:
+    - Trust with opponent DESTROYED
+    - Locker room standing tanks
+    - Federation may fine/suspend
+    - History entry creates a permanent memory
+    - Morale impact on the victim (humiliated, angry)
+    - The shooter gets a temporary popularity boost (controversy sells)
+    """
+    sim_log = match.simulation_log or []
+    shoot_spots = [s for s in sim_log if s.get("is_shoot")]
+    if not shoot_spots:
+        return
+
+    shoot_spot = shoot_spots[0]
+    shooter_id = shoot_spot.get("attacker")
+    victim_id = shoot_spot.get("defender")
+
+    shooter = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == shooter_id).first()
+    victim = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == victim_id).first()
+    if not shooter or not victim:
+        return
+
+    # --- Trust DESTROYED between these wrestlers ---
+    rel = db.query(WrestlerRelationshipDB).filter(
+        WrestlerRelationshipDB.world_id == match.world_id,
+        WrestlerRelationshipDB.wrestler1_id.in_([shooter_id, victim_id]),
+        WrestlerRelationshipDB.wrestler2_id.in_([shooter_id, victim_id]),
+    ).first()
+    if rel:
+        rel.trust_level = max(0, min(10, (rel.trust_level or 50) - 40))  # Near-zero
+        rel.rivalry_heat = min(100, (rel.rivalry_heat or 0) + 30)  # Real heat
+        rel.real_relationship = "enemies"  # This is personal now
+        logger.info("SHOOT: Trust between %s and %s DESTROYED (now %d)",
+                    shooter.name, victim.name, rel.trust_level)
+
+    # --- Locker room standing tanks for the shooter ---
+    shooter.locker_room_standing = "toxic"
+
+    # --- Federation discipline ---
+    from models.game_models import ContractDB, GameFederationDB
+    contract = db.query(ContractDB).filter(
+        ContractDB.wrestler_id == shooter_id,
+        ContractDB.status == "active",
+    ).first()
+    if contract:
+        fed = db.query(GameFederationDB).filter(
+            GameFederationDB.id == contract.federation_id
+        ).first()
+        if fed:
+            # Fine: 2 weeks salary
+            fine = contract.salary_weekly * 2
+            fed.budget += fine  # Federation collects the fine
+            db.add(GameNarrativeLogDB(
+                world_id=match.world_id,
+                game_date=game_date, tick=0,
+                event_type="discipline_fine",
+                description=f"{shooter.name} fined ${fine:,.0f} for going into business for themselves!",
+                involved_entities=[shooter_id, fed.id],
+                importance=9,
+            ))
+
+            # Strict federations may also suspend
+            if (fed.kayfabe_strictness or 50) > 60:
+                from game_service.world_ticker import advance_game_date
+                suspension_weeks = random.randint(2, 6)
+                shooter.is_injured = True  # Use injury system for suspension
+                shooter.injury_return_date = advance_game_date(game_date, suspension_weeks * 7)
+                db.add(GameNarrativeLogDB(
+                    world_id=match.world_id,
+                    game_date=game_date, tick=0,
+                    event_type="discipline_suspension",
+                    description=f"{shooter.name} SUSPENDED for {suspension_weeks} weeks! Management is furious!",
+                    involved_entities=[shooter_id, fed.id],
+                    importance=9,
+                ))
+
+    # --- History entries: permanent memory for both wrestlers ---
+    db.add(WrestlerHistoryDB(
+        wrestler_id=shooter_id,
+        game_date=game_date,
+        event_type="went_into_business",
+        description=f"Went into business for themselves against {victim.name} — refused to do the job",
+        details={"victim": victim_id, "victim_name": victim.name,
+                 "match_id": match.id, "was_title_match": match.is_title_match},
+    ))
+    db.add(WrestlerHistoryDB(
+        wrestler_id=victim_id,
+        game_date=game_date,
+        event_type="business_victim",
+        description=f"{shooter.name} went into business for themselves — refused to lose to you",
+        details={"shooter": shooter_id, "shooter_name": shooter.name,
+                 "match_id": match.id},
+    ))
+
+    # --- Morale impact ---
+    victim.morale = max(0, victim.morale - random.randint(10, 20))
+    shooter.morale = max(0, min(100, shooter.morale + random.randint(-5, 5)))  # Mixed feelings
+
+    # --- Controversial popularity boost for shooter (controversy sells) ---
+    shooter.popularity = min(100, shooter.popularity + random.randint(2, 8))
+
+    # --- Narrative log for the world ---
+    db.add(GameNarrativeLogDB(
+        world_id=match.world_id,
+        game_date=game_date, tick=0,
+        event_type="went_into_business",
+        description=(
+            f"BACKSTAGE CHAOS: {shooter.name} went into business for themselves against {victim.name}! "
+            f"The planned finish was thrown out the window. Management is LIVID."
+        ),
+        involved_entities=[shooter_id, victim_id],
+        importance=10,  # Maximum importance — this is a defining event
+    ))
+
+    logger.info("SHOOT: %s went into business against %s!", shooter.name, victim.name)

--- a/core_engine/match_engine.py
+++ b/core_engine/match_engine.py
@@ -232,6 +232,10 @@ class MatchSimulator:
         if len(teams) >= 2 and len(participants) >= 4:
             return self._simulate_tag_match(participants)
 
+        # Multi-person match (triple threat, fatal four way, battle royal)
+        if len(participants) > 2:
+            return self._simulate_multi_person(participants)
+
         return self._simulate_singles(participants)
 
     def _simulate_singles(self, participants: List[MatchParticipantState]) -> MatchResult:
@@ -282,6 +286,93 @@ class MatchSimulator:
             winner_id=None,
             finish_type="time_limit_draw",
             finish_description="The match ends in a time limit draw!",
+            match_rating=self._calculate_rating(participants),
+            crowd_heat=self._calculate_heat(),
+            duration_ticks=self.tick,
+            spots=self.spots,
+        )
+
+    def _simulate_multi_person(self, participants: List[MatchParticipantState]) -> MatchResult:
+        """Simulate a multi-person match (triple threat, fatal four way, battle royal).
+
+        Uses elimination logic: when a participant's endurance drops low, they can
+        be eliminated. The last two standing get a proper finishing sequence.
+        """
+        min_len, max_len = self.MATCH_LENGTH.get(self.card_position, (10, 20))
+        # Multi-person matches run a bit longer
+        target_length = random.randint(min_len + 3, max_len + 5)
+
+        active = list(participants)
+        eliminated = []
+
+        while self.tick < target_length + 15 and len(active) >= 2:
+            self.tick += 1
+
+            # Pick a random attacker/defender pair from active participants
+            attacker = random.choice(active)
+            defender = random.choice([p for p in active if p is not attacker])
+
+            spot = self._generate_spot(attacker, defender)
+            self.spots.append(spot)
+            self._apply_spot(spot, attacker, defender)
+
+            if not attacker.finisher_available and attacker.momentum > 75:
+                attacker.finisher_available = True
+
+            # Elimination check: participants with very low endurance can be pinned
+            if len(active) > 2 and self.tick > target_length * 0.3:
+                for p in list(active):
+                    if p is attacker:
+                        continue
+                    if p.endurance < 15 and random.random() < 0.35:
+                        eliminated.append(p)
+                        active.remove(p)
+                        elim_spot = MatchSpot(
+                            tick=self.tick,
+                            attacker_id=attacker.wrestler_id,
+                            defender_id=p.wrestler_id,
+                            move_name="Elimination",
+                            move_type="power",
+                            damage=0,
+                            description=f"{p.name} has been eliminated!",
+                            crowd_reaction="pop",
+                        )
+                        self.spots.append(elim_spot)
+
+            # Near-falls add drama
+            if self.tick > target_length * 0.5 and random.random() < 0.2:
+                near_fall = self._near_fall(attacker, defender)
+                if near_fall:
+                    self.spots.append(near_fall)
+
+            # When down to 2, try for a finish
+            if len(active) == 2 and self.tick >= target_length - 3:
+                finish_spot = self._attempt_finish(attacker, defender)
+                if finish_spot:
+                    self.spots.append(finish_spot)
+                    return self._build_result(finish_spot, attacker, defender, participants)
+
+            if self._should_switch_control(attacker, defender):
+                pass  # In multi-person, control is already random each tick
+
+        # Time limit: pick the participant with the highest momentum as winner
+        if len(active) >= 2:
+            winner = max(active, key=lambda p: p.momentum)
+            loser = [p for p in active if p is not winner][0]
+            return MatchResult(
+                winner_id=winner.wrestler_id,
+                finish_type="pinfall",
+                finish_description=f"{winner.name} pins {loser.name} after a grueling multi-person match!",
+                match_rating=self._calculate_rating(participants),
+                crowd_heat=self._calculate_heat(),
+                duration_ticks=self.tick,
+                spots=self.spots,
+            )
+
+        return MatchResult(
+            winner_id=active[0].wrestler_id if active else None,
+            finish_type="last_person_standing",
+            finish_description="Last person standing wins!",
             match_rating=self._calculate_rating(participants),
             crowd_heat=self._calculate_heat(),
             duration_ticks=self.tick,
@@ -755,6 +846,23 @@ class MatchSimulator:
         highlights = [s for s in self.spots if s.damage >= 10 or s.is_near_fall or s.is_finisher]
         narrative_parts = [s.description for s in highlights[-5:]]  # Last 5 highlights
         narrative = " ".join(narrative_parts)
+
+        # Try LLM-enhanced match summary if enabled
+        import os
+        if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
+            try:
+                from llm_abstraction.provider import get_llm
+                prompt = (
+                    f"Write a 2-3 sentence wrestling match summary. "
+                    f"{attacker.name} defeated {defender.name} via {finish_spot.finish_type or 'pinfall'}. "
+                    f"Key spots: {', '.join(narrative_parts[-3:])}. "
+                    f"Match rating: {self._calculate_rating(participants):.1f} stars."
+                )
+                response = get_llm().generate(prompt, max_tokens=100)
+                if response and response.content and len(response.content.strip()) > 20:
+                    narrative = response.content.strip()
+            except Exception:
+                pass  # Keep template narrative
 
         return MatchResult(
             winner_id=finish_spot.attacker_id,

--- a/core_engine/match_engine.py
+++ b/core_engine/match_engine.py
@@ -33,38 +33,261 @@ MOVES = {
         ("Bodyslam", 6, "power"), ("Clothesline", 7, "power"),
         ("Spinebuster", 10, "power"), ("Gorilla Press", 9, "power"),
         ("Big Boot", 7, "power"), ("Chokeslam", 11, "power"),
+        ("Military Press Slam", 10, "power"), ("Sidewalk Slam", 7, "power"),
+        ("Running Powerslam", 11, "power"), ("Samoan Drop", 8, "power"),
+        ("Fallaway Slam", 9, "power"), ("Avalanche Splash", 10, "power"),
+        ("Pop-Up Powerbomb", 13, "power"), ("Deadlift Suplex", 10, "power"),
     ],
     "technical": [
         ("Arm Drag", 4, "technical"), ("Suplex Combo", 9, "technical"),
         ("German Suplex", 10, "technical"), ("Snap Mare", 3, "technical"),
         ("Dragon Screw", 7, "technical"), ("Backbreaker", 8, "technical"),
         ("Neckbreaker", 7, "technical"), ("Brainbuster", 11, "technical"),
+        ("Northern Lights Suplex", 9, "technical"), ("T-Bone Suplex", 8, "technical"),
+        ("Belly-to-Belly Suplex", 8, "technical"), ("Fisherman Suplex", 9, "technical"),
+        ("Tiger Suplex", 10, "technical"), ("Rolling Elbow", 7, "technical"),
+        ("Cobra Clutch Slam", 9, "technical"), ("Bridging German", 11, "technical"),
     ],
     "aerial": [
         ("Dropkick", 6, "aerial"), ("Moonsault", 11, "aerial"),
         ("Diving Crossbody", 9, "aerial"), ("Hurricanrana", 8, "aerial"),
         ("450 Splash", 12, "aerial"), ("Springboard Elbow", 8, "aerial"),
         ("Frog Splash", 10, "aerial"), ("Shooting Star Press", 13, "aerial"),
+        ("Corkscrew Plancha", 10, "aerial"), ("Springboard Cutter", 11, "aerial"),
+        ("Tope Con Hilo", 9, "aerial"), ("Phoenix Splash", 14, "aerial"),
+        ("Sasuke Special", 10, "aerial"), ("Spanish Fly", 12, "aerial"),
+        ("Diving Elbow Drop", 9, "aerial"), ("Asai Moonsault", 11, "aerial"),
     ],
     "brawling": [
         ("Right Hand", 4, "brawling"), ("Uppercut", 5, "brawling"),
         ("Knee Strike", 7, "brawling"), ("Elbow Smash", 6, "brawling"),
         ("Headbutt", 5, "brawling"), ("Lariat", 9, "brawling"),
         ("Running Knee", 10, "brawling"), ("Discus Punch", 8, "brawling"),
+        ("Throat Thrust", 5, "brawling"), ("Spinning Backfist", 8, "brawling"),
+        ("Knife-Edge Chop", 4, "brawling"), ("Avalanche Corner Splash", 8, "brawling"),
+        ("European Uppercut", 6, "brawling"), ("Rebound Lariat", 10, "brawling"),
+        ("Enzuigiri", 7, "brawling"), ("Discus Elbow", 9, "brawling"),
     ],
     "submission": [
         ("Armbar", 6, "submission"), ("Figure Four", 8, "submission"),
         ("Sharpshooter", 9, "submission"), ("Crossface", 8, "submission"),
         ("Sleeper Hold", 5, "submission"), ("Ankle Lock", 9, "submission"),
         ("Kimura", 7, "submission"), ("Triangle Choke", 8, "submission"),
+        ("Boston Crab", 7, "submission"), ("STF", 8, "submission"),
+        ("Koji Clutch", 7, "submission"), ("Dragon Sleeper", 9, "submission"),
+        ("Rings of Saturn", 8, "submission"), ("Octopus Hold", 7, "submission"),
+        ("Cattle Mutilation", 9, "submission"), ("Rear Naked Choke", 8, "submission"),
     ],
 }
+
+# ---------------------------------------------------------------------------
+# Signature move pools by archetype — used when populating wrestlers
+# ---------------------------------------------------------------------------
+
+SIGNATURE_MOVE_POOLS = {
+    "monster_heel": [
+        ("Tombstone Piledriver", 14, "power"), ("Running Big Boot", 9, "power"),
+        ("Release German Suplex", 10, "power"), ("Torture Rack", 10, "submission"),
+        ("Snake Eyes", 7, "brawling"), ("Tree of Woe Stomp", 8, "brawling"),
+    ],
+    "underdog_face": [
+        ("Sling Blade", 8, "technical"), ("Stunner", 12, "brawling"),
+        ("Tornado DDT", 10, "aerial"), ("La Magistral Cradle", 7, "technical"),
+        ("Diving Headbutt", 9, "aerial"), ("Thesz Press", 7, "brawling"),
+    ],
+    "cocky_technician": [
+        ("Rolling Thunder", 9, "technical"), ("Regal Cutter", 10, "technical"),
+        ("Perfect Plex", 10, "technical"), ("Bridging Suplex", 9, "technical"),
+        ("Figure Eight", 10, "submission"), ("Standing Moonsault", 9, "aerial"),
+    ],
+    "silent_assassin": [
+        ("Running Knee Strike", 11, "brawling"), ("Kinshasa", 12, "brawling"),
+        ("Roundhouse Kick", 10, "brawling"), ("Buzzsaw Kick", 9, "brawling"),
+        ("Snap DDT", 8, "technical"), ("Penalty Kick", 10, "brawling"),
+    ],
+    "cult_leader": [
+        ("Sister Abigail", 12, "power"), ("Mandible Claw", 8, "submission"),
+        ("Uranage Slam", 10, "power"), ("Running Senton", 9, "power"),
+        ("Swinging Neckbreaker", 8, "technical"), ("Eye Rake Combo", 6, "brawling"),
+    ],
+    "comedy_act": [
+        ("People's Elbow", 8, "brawling"), ("Worm", 6, "brawling"),
+        ("Bionic Elbow", 7, "brawling"), ("Stink Face", 3, "brawling"),
+        ("Atomic Drop", 6, "power"), ("Airplane Spin", 5, "power"),
+    ],
+    "anti_hero": [
+        ("Stunner", 12, "brawling"), ("Pedigree", 13, "power"),
+        ("Curb Stomp", 11, "brawling"), ("GTS", 12, "technical"),
+        ("Package Piledriver", 13, "power"), ("V-Trigger", 10, "brawling"),
+    ],
+    "legacy": [
+        ("Crossface Chicken Wing", 9, "submission"), ("Slingshot Suplex", 8, "technical"),
+        ("Figure Four Leglock", 9, "submission"), ("Spinning Toe Hold", 7, "submission"),
+        ("Flying Body Press", 9, "aerial"), ("Bionic Elbow", 7, "brawling"),
+    ],
+    "patriot": [
+        ("Patriot Slam", 11, "power"), ("Patriot Lock", 9, "submission"),
+        ("Red White and Blue Thunder Bomb", 12, "power"), ("Flying Shoulder Tackle", 8, "power"),
+        ("Angle Slam", 10, "technical"), ("Running Bulldog", 7, "brawling"),
+    ],
+    "daredevil": [
+        ("Swanton Bomb", 12, "aerial"), ("Springboard 450", 14, "aerial"),
+        ("Double Rotation Moonsault", 14, "aerial"), ("Corkscrew Shooting Star", 15, "aerial"),
+        ("Coast-to-Coast Dropkick", 12, "aerial"), ("Sky Twister Press", 13, "aerial"),
+    ],
+}
+
+# Archetype-specific finisher pools (name, damage, type)
+ARCHETYPE_FINISHERS = {
+    "monster_heel": [
+        ("The Annihilation", "power"), ("Tomb of Darkness", "power"),
+        ("The Extinction", "power"), ("Final Judgment", "power"),
+    ],
+    "underdog_face": [
+        ("Heart of a Champion", "technical"), ("Against All Odds", "aerial"),
+        ("The Comeback", "brawling"), ("Never Say Die", "technical"),
+    ],
+    "cocky_technician": [
+        ("The Masterpiece", "technical"), ("Perfection", "submission"),
+        ("Technical Knockout", "technical"), ("The Equation", "submission"),
+    ],
+    "silent_assassin": [
+        ("The Kill Shot", "brawling"), ("Silent Night", "brawling"),
+        ("Death Sentence", "brawling"), ("Zero Hour", "brawling"),
+    ],
+    "cult_leader": [
+        ("The Sermon", "power"), ("Enlightenment", "submission"),
+        ("The Awakening", "power"), ("Mass Hysteria", "power"),
+    ],
+    "comedy_act": [
+        ("The Punchline", "brawling"), ("The Gag Reflex", "brawling"),
+        ("Comedy of Errors", "brawling"), ("Lights Out Comedy", "power"),
+    ],
+    "anti_hero": [
+        ("The Reckoning", "brawling"), ("One Final Beat", "power"),
+        ("Bitter End", "power"), ("Anti-Establishment", "brawling"),
+    ],
+    "legacy": [
+        ("The Dynasty", "technical"), ("Legacy Lock", "submission"),
+        ("Generational Shift", "technical"), ("The Inheritance", "power"),
+    ],
+    "patriot": [
+        ("The Patriot Act", "power"), ("Eagle's Landing", "aerial"),
+        ("Freedom Strike", "brawling"), ("National Anthem", "submission"),
+    ],
+    "daredevil": [
+        ("Terminal Velocity", "aerial"), ("The Death-Defier", "aerial"),
+        ("Point of No Return", "aerial"), ("Leap of Faith", "aerial"),
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Match-type-specific spot pools
+# ---------------------------------------------------------------------------
+
+CAGE_SPOTS = [
+    ("throws opponent into the cage wall", 8, "brawling"),
+    ("grinds opponent's face against the steel", 6, "brawling"),
+    ("catapults opponent into the cage", 9, "power"),
+    ("climbs the cage and drops an elbow", 12, "aerial"),
+    ("slams opponent off the cage wall", 10, "power"),
+    ("attempts to escape over the top of the cage", 0, "escape"),
+]
+
+LADDER_SPOTS = [
+    ("drives opponent through a ladder", 12, "power"),
+    ("suplexes opponent onto a ladder", 11, "technical"),
+    ("pushes opponent off the ladder", 13, "aerial"),
+    ("sunset flip powerbomb off the ladder", 15, "power"),
+    ("climbs the ladder and reaches for the prize", 0, "climb"),
+    ("tips the ladder over with opponent on it", 14, "power"),
+]
+
+TABLE_SPOTS = [
+    ("sets up a table at ringside", 0, "setup"),
+    ("powerbombs opponent through the table", 16, "power"),
+    ("superplexes opponent through a table", 18, "power"),
+    ("spears opponent through a table", 15, "brawling"),
+    ("elbow drops opponent through a table from the top", 17, "aerial"),
+]
+
+HELL_IN_A_CELL_SPOTS = [
+    ("throws opponent into the cell wall", 9, "brawling"),
+    ("slams opponent onto the steel steps", 10, "power"),
+    ("climbs the outside of the cell", 0, "climb"),
+    ("chokeslams opponent off the cell roof", 20, "power"),
+    ("drives opponent through the announce table", 14, "brawling"),
+    ("uses the cell door as a weapon", 8, "brawling"),
+]
+
+IRON_MAN_FALL_DESCRIPTIONS = [
+    "scores a fall with a pinfall!", "scores a fall via submission!",
+    "scores a fall after a devastating finisher!",
+]
+
+# ---------------------------------------------------------------------------
+# Charisma style match spots
+# ---------------------------------------------------------------------------
+
+TAUNT_SPOTS = {
+    "cocky": [
+        "{name} flexes over their fallen opponent!", "{name} mocks the crowd with a strut!",
+        "{name} slaps the taste out of {opponent}'s mouth and laughs!",
+    ],
+    "intense": [
+        "{name} lets out a primal scream!", "{name} no-sells the last move and hulks up!",
+        "{name} stares daggers through {opponent} — pure intensity!",
+    ],
+    "funny": [
+        "{name} does a little dance for the crowd!", "{name} pretends to answer a phone call mid-match!",
+        "{name} offers a handshake — then pulls it away! Classic!",
+    ],
+    "mysterious": [
+        "{name} sits up like something out of a horror movie!",
+        "{name} points to the sky ominously...", "{name} tilts their head — unsettling...",
+    ],
+    "humble": [
+        "{name} fires up the crowd! They're feeding off the energy!",
+        "{name} slaps the mat — they're not done yet!",
+        "{name} bows to the crowd before delivering the next blow!",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Venue atmosphere modifiers
+# ---------------------------------------------------------------------------
+
+VENUE_ATMOSPHERE = {
+    "club": {"capacity_range": (200, 1500), "rating_mod": -0.2, "crowd_energy": 0.8,
+             "description": "intimate venue"},
+    "arena": {"capacity_range": (2000, 10000), "rating_mod": 0.0, "crowd_energy": 1.0,
+              "description": "electric arena"},
+    "large_arena": {"capacity_range": (10001, 25000), "rating_mod": 0.1, "crowd_energy": 1.1,
+                    "description": "massive arena"},
+    "stadium": {"capacity_range": (25001, 80000), "rating_mod": 0.2, "crowd_energy": 1.2,
+                "description": "roaring stadium"},
+}
+
+def get_venue_tier(capacity: int) -> str:
+    """Determine venue tier from capacity."""
+    if capacity <= 1500:
+        return "club"
+    elif capacity <= 10000:
+        return "arena"
+    elif capacity <= 25000:
+        return "large_arena"
+    return "stadium"
 
 CROWD_REACTIONS = [
     "The crowd erupts!", "Huge pop from the fans!", "The audience is on their feet!",
     "Mixed reaction from the crowd.", "The fans are booing loudly!",
     "Chants break out across the arena!", "Stunned silence from the crowd.",
     "The energy in the building is electric!", "The crowd is split down the middle!",
+    "THIS IS AWESOME chants ring out!", "FIGHT FOREVER! FIGHT FOREVER!",
+    "The crowd is going absolutely ballistic!", "You can barely hear yourself think!",
+    "Dueling chants fill the arena!", "The fans throw streamers into the ring!",
+    "A hush falls over the crowd...", "The building is shaking!",
+    "Standing ovation from the crowd!", "The fans are in disbelief!",
 ]
 
 REVERSAL_DESCRIPTIONS = [
@@ -121,6 +344,10 @@ DOUBLE_TEAM_MOVES = [
     ("Double Suplex", 14), ("Double Clothesline", 10),
     ("Aided Powerbomb", 16), ("Tandem Neckbreaker", 12),
     ("Double Dropkick", 11), ("Combo Finisher", 18),
+    ("Doomsday Device", 17), ("Magic Killer", 15),
+    ("3D (Dudley Death Drop)", 16), ("Poetry in Motion", 13),
+    ("Total Elimination", 15), ("Shatter Machine", 16),
+    ("Hart Attack", 14), ("Rocket Launcher", 13),
 ]
 
 
@@ -136,12 +363,16 @@ class MatchParticipantState:
     health: float = 100.0  # 0-100, match ends when pinned at low health
     momentum: float = 50.0  # 0-100, determines who's on offense
     stamina: float = 100.0  # Decreases with each move
+    endurance: float = 100.0  # For multi-person elimination tracking
     finisher_available: bool = False
     finisher_used: bool = False
     stats: Dict[str, int] = field(default_factory=dict)
     finisher_name: str = "Finisher"
     alignment: str = "face"
     team: Optional[int] = None
+    signature_moves: list = field(default_factory=list)  # [(name, damage, type), ...]
+    charisma_style: str = "humble"  # cocky, humble, intense, funny, mysterious
+    hometown_bonus: bool = False  # True if wrestling in home region
 
 
 @dataclass
@@ -550,7 +781,69 @@ class MatchSimulator:
     def _generate_spot(self, attacker: MatchParticipantState,
                        defender: MatchParticipantState) -> MatchSpot:
         """Generate a single match spot."""
-        # Pick move category based on attacker's strongest stats
+        # --- Charisma style taunt (15% chance when momentum is high) ---
+        if attacker.momentum > 60 and random.random() < 0.15:
+            style = attacker.charisma_style or "humble"
+            if style in TAUNT_SPOTS:
+                taunt = random.choice(TAUNT_SPOTS[style]).format(
+                    name=attacker.name, opponent=defender.name)
+                momentum_gain = 5
+                if style == "intense":
+                    momentum_gain = 10  # No-sell / hulk-up gets huge crowd pop
+                elif style == "cocky":
+                    momentum_gain = 3  # Risk: cocky taunts can backfire
+                    if random.random() < 0.25:
+                        # Backfire: opponent fires up
+                        return MatchSpot(
+                            tick=self.tick,
+                            attacker_id=defender.wrestler_id,
+                            defender_id=attacker.wrestler_id,
+                            move_name="Fired Up",
+                            move_type="brawling",
+                            damage=3,
+                            description=f"{attacker.name} taunts — but {defender.name} fires up! The crowd goes wild!",
+                            crowd_reaction="Huge pop from the fired-up underdog!",
+                            heat_change=5,
+                        )
+                return MatchSpot(
+                    tick=self.tick,
+                    attacker_id=attacker.wrestler_id,
+                    defender_id=defender.wrestler_id,
+                    move_name="Taunt",
+                    move_type="charisma",
+                    damage=0,
+                    description=taunt,
+                    crowd_reaction=random.choice(CROWD_REACTIONS),
+                    heat_change=momentum_gain,
+                )
+
+        # --- Match-type-specific spots ---
+        if self.stipulation and random.random() < 0.25:
+            stip_spot = self._generate_stipulation_spot(attacker, defender)
+            if stip_spot:
+                return stip_spot
+
+        # --- Signature move (20% chance when momentum > 55, once per match per sig) ---
+        if (attacker.signature_moves and attacker.momentum > 55
+                and random.random() < 0.20):
+            sig = random.choice(attacker.signature_moves)
+            sig_name, sig_damage, sig_type = sig[0], sig[1], sig[2]
+            attack_stat = attacker.stats.get(sig_type, 50)
+            damage = int(sig_damage * (attack_stat / 50) * (attacker.stamina / 100))
+            damage = max(3, damage)
+            return MatchSpot(
+                tick=self.tick,
+                attacker_id=attacker.wrestler_id,
+                defender_id=defender.wrestler_id,
+                move_name=sig_name,
+                move_type=sig_type,
+                damage=damage,
+                description=f"{attacker.name} hits the {sig_name}! Signature move!",
+                crowd_reaction="The crowd erupts for the signature move!",
+                heat_change=random.randint(3, 6),
+            )
+
+        # --- Standard move selection ---
         category = self._pick_move_category(attacker)
         move_name, base_damage, move_type = random.choice(MOVES[category])
 
@@ -560,6 +853,10 @@ class MatchSimulator:
         stamina_factor = attacker.stamina / 100
         damage = int(base_damage * (attack_stat / 50) * stamina_factor * (1 - defense_stat / 200))
         damage = max(1, damage)
+
+        # Hometown advantage: small damage boost
+        if attacker.hometown_bonus:
+            damage = int(damage * 1.1)
 
         # Check for reversal
         was_reversed = False
@@ -608,6 +905,110 @@ class MatchSimulator:
             description=desc,
         )
 
+    def _generate_stipulation_spot(self, attacker: MatchParticipantState,
+                                   defender: MatchParticipantState) -> Optional[MatchSpot]:
+        """Generate a match-type-specific special spot."""
+        stip = (self.stipulation or "").lower()
+
+        if "cage" in stip or "steel cage" in stip:
+            desc, base_dmg, stype = random.choice(CAGE_SPOTS)
+            if stype == "escape":
+                # Cage escape attempt — only works if momentum > 80
+                if attacker.momentum > 80 and attacker.health > 40:
+                    return MatchSpot(
+                        tick=self.tick, attacker_id=attacker.wrestler_id,
+                        defender_id=defender.wrestler_id,
+                        move_name="Cage Escape Attempt", move_type="technical",
+                        damage=0,
+                        description=f"{attacker.name} is climbing the cage! Can they escape?!",
+                        crowd_reaction="The crowd is on their feet!",
+                        heat_change=5,
+                    )
+                return None
+            damage = int(base_dmg * (attacker.stats.get("brawling", 50) / 50))
+            return MatchSpot(
+                tick=self.tick, attacker_id=attacker.wrestler_id,
+                defender_id=defender.wrestler_id,
+                move_name="Cage Spot", move_type="brawling",
+                damage=max(3, damage),
+                description=f"{attacker.name} {desc}!",
+                crowd_reaction=random.choice(CROWD_REACTIONS),
+                heat_change=random.randint(2, 5),
+            )
+
+        elif "ladder" in stip:
+            desc, base_dmg, stype = random.choice(LADDER_SPOTS)
+            if stype == "climb":
+                if attacker.momentum > 70:
+                    return MatchSpot(
+                        tick=self.tick, attacker_id=attacker.wrestler_id,
+                        defender_id=defender.wrestler_id,
+                        move_name="Ladder Climb", move_type="aerial",
+                        damage=0,
+                        description=f"{attacker.name} is climbing the ladder! Fingers inches from the prize!",
+                        crowd_reaction="This could be it!",
+                        heat_change=6,
+                    )
+                return None
+            damage = int(base_dmg * (attacker.stats.get("power", 50) / 50))
+            return MatchSpot(
+                tick=self.tick, attacker_id=attacker.wrestler_id,
+                defender_id=defender.wrestler_id,
+                move_name="Ladder Spot", move_type=stype,
+                damage=max(5, damage),
+                description=f"{attacker.name} {desc}!",
+                crowd_reaction="OH MY GOD!",
+                heat_change=random.randint(3, 7),
+            )
+
+        elif "table" in stip:
+            desc, base_dmg, stype = random.choice(TABLE_SPOTS)
+            if stype == "setup":
+                return MatchSpot(
+                    tick=self.tick, attacker_id=attacker.wrestler_id,
+                    defender_id=defender.wrestler_id,
+                    move_name="Table Setup", move_type="power",
+                    damage=0,
+                    description=f"{attacker.name} {desc}!",
+                    crowd_reaction="The crowd knows what's coming!",
+                    heat_change=3,
+                )
+            damage = int(base_dmg * (attacker.stats.get("power", 50) / 50))
+            return MatchSpot(
+                tick=self.tick, attacker_id=attacker.wrestler_id,
+                defender_id=defender.wrestler_id,
+                move_name="Table Spot", move_type=stype,
+                damage=max(8, damage), is_finish=False,
+                description=f"{attacker.name} {desc}!",
+                crowd_reaction="THROUGH THE TABLE!",
+                heat_change=random.randint(5, 8),
+            )
+
+        elif "hell" in stip or "cell" in stip:
+            desc, base_dmg, stype = random.choice(HELL_IN_A_CELL_SPOTS)
+            if stype == "climb":
+                return MatchSpot(
+                    tick=self.tick, attacker_id=attacker.wrestler_id,
+                    defender_id=defender.wrestler_id,
+                    move_name="Cell Climb", move_type="aerial",
+                    damage=0,
+                    description=f"{attacker.name} {desc}! This is getting dangerous!",
+                    crowd_reaction="Don't do it! DON'T DO IT!",
+                    heat_change=7,
+                )
+            damage = int(base_dmg * (attacker.stats.get("brawling", 50) / 50))
+            return MatchSpot(
+                tick=self.tick, attacker_id=attacker.wrestler_id,
+                defender_id=defender.wrestler_id,
+                move_name="Cell Spot", move_type=stype,
+                damage=max(5, damage),
+                description=f"{attacker.name} {desc}!",
+                crowd_reaction="GOOD GOD ALMIGHTY!",
+                heat_change=random.randint(4, 8),
+            )
+
+        return None
+
     def _pick_move_category(self, wrestler: MatchParticipantState) -> str:
         """Pick a move category weighted by wrestler's stats."""
         categories = ["power", "technical", "aerial", "brawling", "submission"]
@@ -633,6 +1034,12 @@ class MatchSimulator:
         # Stamina drain
         attacker.stamina = max(0, attacker.stamina - random.uniform(1.5, 3.5))
         defender.stamina = max(0, defender.stamina - random.uniform(0.5, 1.5))
+
+        # Endurance drain (tracks cumulative damage for multi-person eliminations)
+        if not spot.was_reversed:
+            defender.endurance = max(0, defender.endurance - spot.damage * 0.8)
+        else:
+            attacker.endurance = max(0, attacker.endurance - spot.damage * 0.8)
 
     def _should_switch_control(self, attacker: MatchParticipantState,
                                defender: MatchParticipantState) -> bool:
@@ -824,7 +1231,27 @@ class MatchSimulator:
         # Interference penalty — cheating cheapens ratings slightly
         interference_penalty = -0.2 if self._interference_happened else 0
 
-        rating = (base_quality * 2.5) + variety_bonus + near_fall_bonus + reversal_bonus + length_bonus + title_bonus + rivalry_bonus + interference_penalty
+        # Signature move bonus — fans love seeing signature spots
+        sig_spots = sum(1 for s in self.spots if "Signature" in s.description or "signature" in s.description)
+        sig_bonus = min(sig_spots * 0.1, 0.3)
+
+        # Stipulation bonus — gimmick matches get a bump for spectacle
+        stip_bonus = 0.0
+        stip = (self.stipulation or "").lower()
+        if "cage" in stip or "cell" in stip:
+            stip_bonus = 0.2
+        elif "ladder" in stip or "table" in stip:
+            stip_bonus = 0.25
+        elif stip and stip not in ("", "standard"):
+            stip_bonus = 0.1
+
+        # Venue atmosphere bonus (set by caller via show_momentum scaling)
+        venue_tier = get_venue_tier(self.show_momentum * 100)  # approximate
+        venue_mod = VENUE_ATMOSPHERE.get(venue_tier, {}).get("rating_mod", 0)
+
+        rating = ((base_quality * 2.5) + variety_bonus + near_fall_bonus +
+                  reversal_bonus + length_bonus + title_bonus + rivalry_bonus +
+                  interference_penalty + sig_bonus + stip_bonus + venue_mod)
         rating = min(5.0, max(0.5, rating + random.uniform(-0.3, 0.3)))
         return round(rating, 1)
 
@@ -914,6 +1341,17 @@ def simulate_match_from_db(db: Session, match: MatchDB, game_date: str = None) -
         cond_modifier = 0.85 + (conditioning / 100) * 0.15  # 0.85-1.0
         stat_modifier *= cond_modifier
 
+        # Load signature moves
+        sig_moves = []
+        if wrestler.signature_moves:
+            for sig in wrestler.signature_moves:
+                if isinstance(sig, (list, tuple)) and len(sig) >= 3:
+                    sig_moves.append(tuple(sig))
+
+        # Load charisma style
+        personality = wrestler.personality_traits or {}
+        charisma_style = personality.get("charisma_style", "humble") if isinstance(personality, dict) else "humble"
+
         state = MatchParticipantState(
             wrestler_id=wrestler.id,
             name=wrestler.name,
@@ -934,6 +1372,8 @@ def simulate_match_from_db(db: Session, match: MatchDB, game_date: str = None) -
             finisher_name=wrestler.finisher_name or "Finisher",
             alignment=wrestler.alignment or "face",
             team=p.team,
+            signature_moves=sig_moves,
+            charisma_style=charisma_style,
         )
         participant_states.append(state)
 

--- a/core_engine/match_engine.py
+++ b/core_engine/match_engine.py
@@ -1274,20 +1274,23 @@ class MatchSimulator:
         narrative_parts = [s.description for s in highlights[-5:]]  # Last 5 highlights
         narrative = " ".join(narrative_parts)
 
-        # Try LLM-enhanced match summary if enabled
+        # LLM-as-journalist: generate a vivid match narrative
         import os
         if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
             try:
-                from llm_abstraction.provider import get_llm
-                prompt = (
-                    f"Write a 2-3 sentence wrestling match summary. "
-                    f"{attacker.name} defeated {defender.name} via {finish_spot.finish_type or 'pinfall'}. "
-                    f"Key spots: {', '.join(narrative_parts[-3:])}. "
-                    f"Match rating: {self._calculate_rating(participants):.1f} stars."
+                from game_service.character_agent import generate_match_narrative
+                llm_narrative = generate_match_narrative(
+                    winner_name=attacker.name,
+                    loser_name=defender.name,
+                    finish_type=finish_spot.finish_type or "pinfall",
+                    finish_description=finish_spot.description,
+                    rating=self._calculate_rating(participants),
+                    key_spots=narrative_parts,
+                    stipulation=self.stipulation or "",
+                    is_title_match=self.is_title_match,
                 )
-                response = get_llm().generate(prompt, max_tokens=100)
-                if response and response.content and len(response.content.strip()) > 20:
-                    narrative = response.content.strip()
+                if llm_narrative and len(llm_narrative.strip()) > 20:
+                    narrative = llm_narrative
             except Exception:
                 pass  # Keep template narrative
 

--- a/core_engine/match_engine.py
+++ b/core_engine/match_engine.py
@@ -393,6 +393,9 @@ class MatchSpot:
     crowd_reaction: str = ""
     heat_change: int = 0
     description: str = ""
+    is_botch: bool = False  # Move went wrong
+    botch_severity: int = 0  # 0=none, 1=minor (stumble), 2=bad (sloppy), 3=dangerous (injury risk)
+    is_shoot: bool = False  # Wrestler went into business for themselves
 
 
 @dataclass
@@ -419,6 +422,10 @@ class MatchResult:
     narrative_summary: str = ""
     interference_occurred: bool = False
     post_match_angle: Optional[Dict[str, Any]] = None
+    botch_count: int = 0  # How many botches occurred
+    botch_events: List[Dict[str, Any]] = field(default_factory=list)  # [{attacker, victim, severity, move}]
+    went_into_business: bool = False  # Someone deviated from the planned finish
+    shoot_wrestler_id: Optional[str] = None  # Who went into business
 
 
 # ---------------------------------------------------------------------------
@@ -452,6 +459,9 @@ class MatchSimulator:
         self.tick = 0
         self._interference_happened = False
         self._dq_triggered = False
+        self._shoot_occurred = False
+        self._shoot_wrestler_id = None
+        self._trust_penalty = 0.0  # Set by caller from relationship trust_level
 
     def simulate(self, participants: List[MatchParticipantState]) -> MatchResult:
         """Run the full match simulation."""
@@ -858,6 +868,39 @@ class MatchSimulator:
         if attacker.hometown_bonus:
             damage = int(damage * 1.1)
 
+        # --- BOTCH CHECK: moves can go wrong ---
+        # Higher-damage moves are riskier. Fatigue, low skill, and low trust increase botch chance.
+        is_botch = False
+        botch_severity = 0
+        move_difficulty = base_damage / 15.0  # 0.0-1.0 scale; power moves = harder to execute
+        if category == "aerial":
+            move_difficulty += 0.15  # Aerial moves are inherently riskier
+        fatigue_factor = max(0, (100 - attacker.stamina) / 200)  # Tired = sloppy
+        skill_factor = max(0, (100 - attack_stat) / 300)  # Low skill = more botches
+        trust_factor = getattr(self, '_trust_penalty', 0.0)  # Low trust with opponent
+
+        botch_chance = (move_difficulty * 0.04) + fatigue_factor + skill_factor + trust_factor
+        botch_chance = min(0.12, botch_chance)  # Cap at 12%
+
+        if random.random() < botch_chance:
+            is_botch = True
+            severity_roll = random.random()
+            if severity_roll < 0.6:
+                botch_severity = 1  # Minor: stumble, awkward landing
+            elif severity_roll < 0.9:
+                botch_severity = 2  # Bad: sloppy execution, crowd notices
+            else:
+                botch_severity = 3  # Dangerous: potential injury
+
+            # Botch modifies damage and description
+            if botch_severity == 1:
+                damage = max(1, damage // 2)
+            elif botch_severity == 2:
+                damage = max(1, damage // 3)
+            elif botch_severity == 3:
+                # Dangerous botch can hurt the DEFENDER more than intended
+                damage = int(damage * 1.3)
+
         # Check for reversal
         was_reversed = False
         reversal_move = None
@@ -868,14 +911,33 @@ class MatchSimulator:
         ) / 500
         reversal_chance *= (defender.momentum / 100)
 
-        if random.random() < reversal_chance:
+        if not is_botch and random.random() < reversal_chance:
             was_reversed = True
             rev_cat = self._pick_move_category(defender)
             reversal_move, rev_dmg, _ = random.choice(MOVES[rev_cat])
             damage = int(rev_dmg * 0.7)  # Reversals do less damage
 
         # Build description
-        if was_reversed:
+        if is_botch:
+            botch_descs = {
+                1: [
+                    f"{attacker.name} goes for {move_name} but stumbles slightly — lands it awkwardly on {defender.name}.",
+                    f"{attacker.name} nearly misses the {move_name} — sloppier than usual.",
+                    f"Slight miscommunication — {attacker.name}'s {move_name} doesn't connect cleanly.",
+                ],
+                2: [
+                    f"{attacker.name} BOTCHES the {move_name}! That looked BAD. {defender.name} barely protected themselves.",
+                    f"That {move_name} went wrong! {attacker.name} and {defender.name} are both shaken up.",
+                    f"Ugly execution on the {move_name} — the crowd groans. {attacker.name} looks frustrated.",
+                ],
+                3: [
+                    f"DANGEROUS BOTCH! {attacker.name}'s {move_name} drops {defender.name} RIGHT on their head!",
+                    f"OH NO! {attacker.name}'s {move_name} goes horribly wrong — {defender.name} lands neck-first!",
+                    f"SCARY MOMENT! The {move_name} from {attacker.name} was NOT supposed to land like that!",
+                ],
+            }
+            desc = random.choice(botch_descs.get(botch_severity, botch_descs[1]))
+        elif was_reversed:
             desc = f"{attacker.name} goes for {move_name}, but {defender.name} {random.choice(REVERSAL_DESCRIPTIONS)} {reversal_move}!"
         else:
             desc = f"{attacker.name} hits {defender.name} with a devastating {move_name}!"
@@ -883,7 +945,14 @@ class MatchSimulator:
         # Crowd reaction
         heat_change = 0
         crowd = ""
-        if damage >= 10 or was_reversed:
+        if is_botch:
+            if botch_severity >= 2:
+                crowd = "The crowd goes quiet... that didn't look right."
+                heat_change = -3  # Botches kill crowd heat
+            elif botch_severity == 1:
+                crowd = "A slight stumble there..."
+                heat_change = -1
+        elif damage >= 10 or was_reversed:
             crowd = random.choice(CROWD_REACTIONS)
             heat_change = random.randint(1, 3)
             if attacker.alignment == "face" and not was_reversed:
@@ -903,6 +972,8 @@ class MatchSimulator:
             crowd_reaction=crowd,
             heat_change=heat_change,
             description=desc,
+            is_botch=is_botch,
+            botch_severity=botch_severity,
         )
 
     def _generate_stipulation_spot(self, attacker: MatchParticipantState,
@@ -1057,12 +1128,63 @@ class MatchSimulator:
 
     def _attempt_finish(self, attacker: MatchParticipantState,
                         defender: MatchParticipantState) -> Optional[MatchSpot]:
-        """Attempt to finish the match."""
+        """Attempt to finish the match.
+
+        Includes "going into business" mechanic: a wrestler with high ego,
+        high frustration, and low morale may refuse to lose as planned,
+        shooting on their opponent to win when they were supposed to lose.
+        """
         # Determine if this is the right person to win
         should_win = True
         if self.planned_winner_id and attacker.wrestler_id != self.planned_winner_id:
             # Not the planned winner — much less likely to hit finish
             should_win = random.random() < 0.08  # 8% chance of upset
+
+            # --- GOING INTO BUSINESS: wrestler refuses to do the job ---
+            # Check if this wrestler has the ego/frustration to go into business
+            ego = attacker.stats.get("ego", 50)
+            frustration = getattr(attacker, '_frustration', 0)
+            morale_mod = getattr(attacker, '_morale', 50)
+
+            # Conditions: high ego + high frustration + low morale + title match stakes
+            shoot_chance = 0.0
+            if ego > 70:
+                shoot_chance += (ego - 70) / 300  # Up to ~0.10
+            if frustration > 60:
+                shoot_chance += (frustration - 60) / 400  # Up to ~0.10
+            if morale_mod < 30:
+                shoot_chance += (30 - morale_mod) / 300  # Up to ~0.10
+            if self.is_title_match:
+                shoot_chance *= 1.5  # Higher stakes = higher temptation
+
+            shoot_chance = min(0.06, shoot_chance)  # Cap at 6% — this is rare and dramatic
+
+            if shoot_chance > 0 and random.random() < shoot_chance:
+                # GOING INTO BUSINESS — wrestler refuses to lose
+                self._shoot_occurred = True
+                self._shoot_wrestler_id = attacker.wrestler_id
+                should_win = True  # They're going to win whether planned or not
+
+                desc = (
+                    f"{attacker.name} was supposed to lose — but they're NOT going down! "
+                    f"{attacker.name} hits the {attacker.finisher_name} with REAL intent! "
+                    f"This was NOT in the script!"
+                )
+                return MatchSpot(
+                    tick=self.tick,
+                    attacker_id=attacker.wrestler_id,
+                    defender_id=defender.wrestler_id,
+                    move_name=attacker.finisher_name,
+                    move_type="finisher",
+                    damage=25,  # Extra damage — they're not protecting their opponent
+                    is_finisher=True,
+                    is_finish=True,
+                    finish_type="pinfall",
+                    crowd_reaction="The crowd doesn't know what just happened... something felt WRONG.",
+                    heat_change=8,
+                    description=desc,
+                    is_shoot=True,
+                )
 
         if not should_win:
             return None
@@ -1294,16 +1416,44 @@ class MatchSimulator:
             except Exception:
                 pass  # Keep template narrative
 
+        # Collect botch events for post-match processing
+        botch_events = []
+        botch_count = 0
+        for s in self.spots:
+            if s.is_botch:
+                botch_count += 1
+                botch_events.append({
+                    "attacker_id": s.attacker_id,
+                    "victim_id": s.defender_id,
+                    "severity": s.botch_severity,
+                    "move": s.move_name,
+                    "tick": s.tick,
+                })
+
+        # Botches hurt match rating
+        rating = self._calculate_rating(participants)
+        if botch_count > 0:
+            botch_penalty = botch_count * 0.15
+            for be in botch_events:
+                if be["severity"] >= 3:
+                    botch_penalty += 0.3  # Dangerous botches tank the rating
+            rating = max(0.5, rating - botch_penalty)
+            rating = round(rating, 1)
+
         return MatchResult(
             winner_id=finish_spot.attacker_id,
             finish_type=finish_spot.finish_type or "pinfall",
             finish_description=finish_spot.description,
-            match_rating=self._calculate_rating(participants),
+            match_rating=rating,
             crowd_heat=self._calculate_heat(),
             duration_ticks=self.tick,
             spots=self.spots,
             narrative_summary=narrative,
             interference_occurred=self._interference_happened,
+            botch_count=botch_count,
+            botch_events=botch_events,
+            went_into_business=self._shoot_occurred,
+            shoot_wrestler_id=self._shoot_wrestler_id,
         )
 
 
@@ -1410,8 +1560,9 @@ def simulate_match_from_db(db: Session, match: MatchDB, game_date: str = None) -
     except Exception:
         pass  # Manager integration is optional
 
-    # Calculate rivalry heat between participants
+    # Calculate rivalry heat and trust between participants
     rivalry_heat = 0
+    trust_penalty = 0.0
     try:
         from models.game_models import WrestlerRelationshipDB
         if len(participant_states) >= 2 and match.world_id:
@@ -1426,8 +1577,37 @@ def simulate_match_from_db(db: Session, match: MatchDB, game_date: str = None) -
             ).first()
             if rel:
                 rivalry_heat = rel.rivalry_heat or 0
+                # Low trust = higher botch chance (wrestlers don't protect each other)
+                trust = rel.trust_level if rel.trust_level is not None else 50
+                if trust < 30:
+                    trust_penalty = (30 - trust) / 300  # Up to +0.10 botch chance
     except Exception:
         pass  # Rivalry heat is optional
+
+    # Load frustration and morale for going-into-business checks
+    try:
+        from models.game_models import WrestlerGoalDB
+        for p_state in participant_states:
+            wrestler = db.query(GameWrestlerDB).filter(
+                GameWrestlerDB.id == p_state.wrestler_id
+            ).first()
+            if wrestler:
+                p_state._morale = wrestler.morale or 50
+                # Get max frustration from active goals
+                max_frust = db.query(WrestlerGoalDB).filter(
+                    WrestlerGoalDB.wrestler_id == p_state.wrestler_id,
+                    WrestlerGoalDB.status == "active",
+                ).all()
+                p_state._frustration = max((g.frustration for g in max_frust), default=0)
+                # Get ego from backstory
+                from models.game_models import WrestlerBackstoryDB
+                backstory = db.query(WrestlerBackstoryDB).filter(
+                    WrestlerBackstoryDB.wrestler_id == p_state.wrestler_id
+                ).first()
+                if backstory and backstory.real_personality:
+                    p_state.stats["ego"] = backstory.real_personality.get("ego", 50)
+    except Exception:
+        pass  # Frustration/ego loading is optional
 
     # Show momentum passed via match attribute (set by world_ticker)
     show_momentum = getattr(match, "_show_momentum", 50)
@@ -1443,6 +1623,7 @@ def simulate_match_from_db(db: Session, match: MatchDB, game_date: str = None) -
         rivalry_heat=rivalry_heat,
         show_momentum=show_momentum,
     )
+    simulator._trust_penalty = trust_penalty
     result = simulator.simulate(participant_states)
 
     # Apply chemistry bonus from wrestler relationships
@@ -1479,6 +1660,9 @@ def simulate_match_from_db(db: Session, match: MatchDB, game_date: str = None) -
             "highlight_tier": (3 if s.is_finisher or s.is_finish else
                                2 if s.is_near_fall or s.was_reversed or s.damage >= 10 else 1),
             "description": s.description,
+            "is_botch": s.is_botch,
+            "botch_severity": s.botch_severity,
+            "is_shoot": s.is_shoot,
         }
         for s in result.spots
     ]

--- a/game_service/character_agent.py
+++ b/game_service/character_agent.py
@@ -238,6 +238,101 @@ def build_character_system_prompt(db: Session, wrestler_id: str) -> str:
         if stats.mic_skill > 80:
             parts.append("You are one of the best talkers in the business.")
 
+    # --- MEMORY: Past events that shape who you are ---
+    try:
+        from models.game_models import WrestlerHistoryDB, CareerHighlightDB
+        # Recent significant events (last 15)
+        history = db.query(WrestlerHistoryDB).filter(
+            WrestlerHistoryDB.wrestler_id == wrestler_id,
+        ).order_by(WrestlerHistoryDB.game_date.desc()).limit(15).all()
+
+        memory_lines = []
+        for evt in reversed(history):  # Chronological order
+            if evt.event_type == "betrayal_victim":
+                memory_lines.append(f"You were BETRAYED: {evt.description}")
+            elif evt.event_type == "betrayal_perpetrator":
+                memory_lines.append(f"You turned on someone: {evt.description}")
+            elif evt.event_type == "title_win":
+                memory_lines.append(f"Career high — you won a title: {evt.description}")
+            elif evt.event_type == "title_loss":
+                memory_lines.append(f"You lost your championship: {evt.description}")
+            elif evt.event_type == "injury":
+                memory_lines.append(f"You were injured: {evt.description}")
+            elif evt.event_type == "botch_victim":
+                details = evt.details or {}
+                culprit = details.get("caused_by_name", "someone")
+                memory_lines.append(f"You were hurt by a botched move from {culprit}. You remember this.")
+            elif evt.event_type == "botch_perpetrator":
+                details = evt.details or {}
+                victim = details.get("victim_name", "someone")
+                memory_lines.append(f"You botched a move and hurt {victim}. This weighs on you.")
+            elif evt.event_type == "went_into_business":
+                memory_lines.append(f"You went into business for yourself: {evt.description}")
+            elif evt.event_type == "business_victim":
+                details = evt.details or {}
+                shooter = details.get("shooter_name", "someone")
+                memory_lines.append(f"{shooter} went into business for themselves against you. You don't forget.")
+            elif evt.event_type == "goal_completed":
+                memory_lines.append(f"Achievement unlocked: {evt.description}")
+            elif evt.event_type in ("match_win", "match_loss"):
+                # Only include notable ones
+                details = evt.details or {}
+                if details.get("notable"):
+                    memory_lines.append(evt.description)
+
+        if memory_lines:
+            parts.append("YOUR MEMORIES (these shape how you think and feel):")
+            for ml in memory_lines[-10:]:  # Cap at 10 most recent
+                parts.append(f"- {ml}")
+
+        # Career highlights — the defining moments
+        highlights = db.query(CareerHighlightDB).filter(
+            CareerHighlightDB.wrestler_id == wrestler_id,
+            CareerHighlightDB.significance >= 7,
+        ).order_by(CareerHighlightDB.significance.desc()).limit(3).all()
+        if highlights:
+            parts.append("YOUR DEFINING MOMENTS:")
+            for h in highlights:
+                parts.append(f"- {h.highlight_type}: {h.description or 'A moment that defined your career.'}")
+    except Exception:
+        pass  # Memory is optional enrichment
+
+    # --- GOALS: What drives you ---
+    try:
+        from models.game_models import WrestlerGoalDB
+        goals = db.query(WrestlerGoalDB).filter(
+            WrestlerGoalDB.wrestler_id == wrestler_id,
+            WrestlerGoalDB.status == "active",
+        ).all()
+        if goals:
+            parts.append("YOUR CURRENT GOALS (these drive your decisions):")
+            for g in goals[:4]:
+                frustration_note = ""
+                if g.frustration > 60:
+                    frustration_note = " — you are FRUSTRATED this hasn't happened yet"
+                elif g.frustration > 30:
+                    frustration_note = " — you're getting impatient"
+                parts.append(f"- {g.goal_type.replace('_', ' ')} (progress: {g.progress}%){frustration_note}")
+    except Exception:
+        pass  # Goals are optional enrichment
+
+    # --- GRUDGES & TRUST: Who you trust and who you don't ---
+    try:
+        for rel in rels[:6]:
+            other_id = rel.wrestler2_id if rel.wrestler1_id == wrestler_id else rel.wrestler1_id
+            other = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == other_id).first()
+            if not other:
+                continue
+            trust = rel.trust_level or 50
+            if trust < 20:
+                parts.append(f"You deeply DISTRUST {other.name}. Something happened between you two.")
+            elif trust < 35:
+                parts.append(f"You are wary of {other.name}. Trust has been broken.")
+            elif trust > 80 and rel.real_relationship == "friends":
+                parts.append(f"You trust {other.name} completely — a true friend in this business.")
+    except Exception:
+        pass  # Trust context is optional
+
     parts.append(
         "Stay in character at all times. Never break the fourth wall. "
         "Keep responses concise (2-4 sentences unless asked for more)."

--- a/game_service/character_agent.py
+++ b/game_service/character_agent.py
@@ -1,0 +1,796 @@
+"""
+Character Agent — LLMs operating AS wrestlers and bookers in the simulation.
+
+This is the heart of "LLMFed": each wrestler is an LLM-driven character with
+persistent identity, memory of recent events, and the ability to make decisions
+that shape the simulation. When LLMFED_USE_LLM is not set, every function
+returns a template-based fallback so the simulation runs identically without
+an LLM provider configured.
+
+Integration points:
+- character_decide(): Wrestler decides what to do (challenge, ally, betray, cut promo)
+- character_speak(): Wrestler generates in-character speech (promos, social media)
+- character_react(): Wrestler reacts to an event (loss, betrayal, title win)
+- booker_decide(): Head booker AI makes creative decisions for a federation
+- generate_match_narrative(): Post-match narrative from the characters' perspective
+"""
+
+import logging
+import os
+import random
+from typing import Optional, Dict, Any, List
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+USE_LLM = os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes")
+
+# Cache the LLM instance to avoid repeated initialization
+_llm_instance = None
+
+
+def _get_llm():
+    """Get or create the LLM singleton. Returns None if unavailable."""
+    global _llm_instance
+    if _llm_instance is not None:
+        return _llm_instance
+    try:
+        from llm_abstraction.provider import get_llm
+        _llm_instance = get_llm()
+        return _llm_instance
+    except Exception as e:
+        logger.debug("LLM not available: %s", e)
+        return None
+
+
+def _llm_call(system_msg: str, user_msg: str, fallback: str,
+              temperature: float = 0.8, max_tokens: int = 200) -> str:
+    """Call the LLM with a system/user prompt pair. Returns fallback on any failure."""
+    if not USE_LLM:
+        return fallback
+    llm = _get_llm()
+    if not llm:
+        return fallback
+    try:
+        response = llm.generate(
+            user_msg, system_message=system_msg,
+            temperature=temperature, max_tokens=max_tokens,
+        )
+        if response and response.content and len(response.content.strip()) > 10:
+            return response.content.strip()
+    except Exception as e:
+        logger.debug("LLM call failed, using fallback: %s", e)
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Character context: builds the LLM's "identity" for a wrestler
+# ---------------------------------------------------------------------------
+
+ARCHETYPE_PERSONALITIES = {
+    "monster_heel": "You are a terrifying, dominant force. You speak in short, menacing sentences. You don't beg — you TAKE. Violence is your language.",
+    "underdog_face": "You are the scrappy underdog who never quits. You speak from the heart, with fire and determination. Every setback makes you fight harder.",
+    "cocky_technician": "You are a genius in the ring and you KNOW it. You speak with intellectual superiority, referencing technique and strategy. Everyone else is beneath you.",
+    "silent_assassin": "You are cold, calculated, lethal. You speak rarely, and when you do, every word cuts. You let your actions in the ring speak louder.",
+    "cult_leader": "You are a manipulative visionary. You speak in riddles and prophecies. You see yourself as enlightened, everyone else as sheep to be guided.",
+    "comedy_act": "You are hilarious and self-aware. You crack jokes, break tension, and don't take yourself too seriously. But beneath the comedy, you can fight.",
+    "anti_hero": "You play by your own rules. You're not a hero, not a villain — just real. You speak bluntly, reject authority, and do what you want.",
+    "legacy": "You carry the weight of a legendary family name. You speak with pride about tradition and heritage, constantly proving you belong on your own merits.",
+    "patriot": "You fight for the people, for something bigger than yourself. You speak with passion and conviction. Your cause gives you strength.",
+    "daredevil": "You are fearless and reckless. You speak with manic energy, always chasing the next thrill. Pain is just proof you're alive.",
+}
+
+ALIGNMENT_MODIFIERS = {
+    "face": "You generally do the right thing and care about the fans' support.",
+    "heel": "You are selfish, deceitful, and willing to cheat to win. You despise the fans.",
+    "tweener": "You walk the line between hero and villain. Your morality is situational.",
+}
+
+
+def build_character_system_prompt(db: Session, wrestler_id: str) -> str:
+    """Build a rich system prompt that makes the LLM embody this wrestler.
+
+    Pulls from: gimmick archetype, voice style, alignment, backstory,
+    recent events, active storylines, relationships, and career state.
+    """
+    from models.game_models import (
+        GameWrestlerDB, WrestlerStatsDB, GimmickHistoryDB,
+        WrestlerBackstoryDB, StorylineDB, StorylineParticipantDB,
+        WrestlerRelationshipDB, ContractDB, GameFederationDB,
+        ChampionshipDB,
+    )
+
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == wrestler_id
+    ).first()
+    if not wrestler:
+        return "You are a professional wrestler."
+
+    stats = db.query(WrestlerStatsDB).filter(
+        WrestlerStatsDB.wrestler_id == wrestler_id
+    ).first()
+
+    gimmick = db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler_id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+
+    backstory = db.query(WrestlerBackstoryDB).filter(
+        WrestlerBackstoryDB.wrestler_id == wrestler_id,
+    ).first()
+
+    # Core identity
+    archetype = gimmick.archetype if gimmick else "anti_hero"
+    personality = ARCHETYPE_PERSONALITIES.get(archetype, ARCHETYPE_PERSONALITIES["anti_hero"])
+    alignment = ALIGNMENT_MODIFIERS.get(wrestler.alignment or "face", "")
+
+    parts = [
+        f"You ARE {wrestler.name}, a professional wrestler.",
+        personality,
+        alignment,
+    ]
+
+    # Voice style from gimmick
+    if gimmick and gimmick.voice_style:
+        vs = gimmick.voice_style
+        if vs.get("vocabulary"):
+            parts.append(f"Your vocabulary is {vs['vocabulary']}.")
+        if vs.get("cadence"):
+            parts.append(f"Your speaking cadence is {vs['cadence']}.")
+        if vs.get("catchphrases"):
+            parts.append(f"Your catchphrases include: {', '.join(vs['catchphrases'][:3])}")
+        if vs.get("speech_patterns"):
+            parts.append(f"Speech patterns: {', '.join(vs['speech_patterns'])}")
+
+    # Physical identity
+    parts.append(
+        f"You are {wrestler.age} years old, a {wrestler.weight_class} "
+        f"from {wrestler.hometown or 'parts unknown'}."
+    )
+    if wrestler.finisher_name:
+        parts.append(f"Your finishing move is the {wrestler.finisher_name}.")
+    if wrestler.catchphrase:
+        parts.append(f'Your catchphrase: "{wrestler.catchphrase}"')
+
+    # Career state
+    parts.append(f"Popularity: {wrestler.popularity}/100. Morale: {wrestler.morale}/100.")
+    if wrestler.career_phase:
+        parts.append(f"Career phase: {wrestler.career_phase}.")
+
+    # Current federation
+    contract = db.query(ContractDB).filter(
+        ContractDB.wrestler_id == wrestler_id,
+        ContractDB.status == "active",
+    ).first()
+    if contract:
+        fed = db.query(GameFederationDB).filter(
+            GameFederationDB.id == contract.federation_id
+        ).first()
+        if fed:
+            parts.append(f"You work for {fed.name}.")
+
+    # Championships
+    titles = db.query(ChampionshipDB).filter(
+        ChampionshipDB.current_holder_id == wrestler_id,
+    ).all()
+    if titles:
+        title_names = [t.name for t in titles]
+        parts.append(f"You currently hold: {', '.join(title_names)}.")
+    else:
+        parts.append("You do not currently hold any championships.")
+
+    # Active storylines
+    storyline_parts = db.query(StorylineParticipantDB).filter(
+        StorylineParticipantDB.wrestler_id == wrestler_id,
+    ).all()
+    for sp in storyline_parts[:3]:
+        sl = db.query(StorylineDB).filter(
+            StorylineDB.id == sp.storyline_id,
+            StorylineDB.status.in_(["brewing", "active", "climax"]),
+        ).first()
+        if sl:
+            rival_parts = db.query(StorylineParticipantDB).filter(
+                StorylineParticipantDB.storyline_id == sl.id,
+                StorylineParticipantDB.wrestler_id != wrestler_id,
+            ).all()
+            rival_names = []
+            for rp in rival_parts[:2]:
+                rival = db.query(GameWrestlerDB).filter(
+                    GameWrestlerDB.id == rp.wrestler_id
+                ).first()
+                if rival:
+                    rival_names.append(rival.name)
+            if rival_names:
+                heat_desc = "heated" if sl.heat > 70 else "building" if sl.heat > 40 else "simmering"
+                parts.append(
+                    f"You are in a {heat_desc} {sl.storyline_type} "
+                    f"('{sl.name}') with {', '.join(rival_names)}. "
+                    f"Your role: {sp.role}."
+                )
+
+    # Key relationships
+    rels = db.query(WrestlerRelationshipDB).filter(
+        (WrestlerRelationshipDB.wrestler1_id == wrestler_id) |
+        (WrestlerRelationshipDB.wrestler2_id == wrestler_id),
+    ).all()
+    for rel in rels[:4]:
+        other_id = rel.wrestler2_id if rel.wrestler1_id == wrestler_id else rel.wrestler1_id
+        other = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == other_id).first()
+        if other and (rel.rivalry_heat or 0) > 30:
+            parts.append(f"You have a rivalry with {other.name} (heat: {rel.rivalry_heat}/100).")
+        elif other and rel.real_relationship == "friends":
+            parts.append(f"{other.name} is a real-life friend.")
+
+    # Backstory flavor
+    if backstory:
+        if backstory.wrestling_motivation:
+            parts.append(f"You got into wrestling because of: {backstory.wrestling_motivation}.")
+        if backstory.pre_wrestling_career:
+            parts.append(f"Before wrestling, you were a {backstory.pre_wrestling_career}.")
+
+    # Stats shape behavior
+    if stats:
+        if stats.charisma > 80:
+            parts.append("You are incredibly charismatic — the crowd hangs on your every word.")
+        elif stats.charisma < 30:
+            parts.append("You struggle on the mic — keep it short and let actions speak.")
+        if stats.mic_skill > 80:
+            parts.append("You are one of the best talkers in the business.")
+
+    parts.append(
+        "Stay in character at all times. Never break the fourth wall. "
+        "Keep responses concise (2-4 sentences unless asked for more)."
+    )
+
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Template-based fallback decisions (used when LLM is off)
+# ---------------------------------------------------------------------------
+
+FALLBACK_DECISIONS = {
+    "monster_heel": ["intimidate_locker_room", "demand_title_shot", "attack_rival"],
+    "underdog_face": ["train_harder", "cut_passionate_promo", "challenge_bully"],
+    "cocky_technician": ["mock_opponent", "demand_respect", "issue_open_challenge"],
+    "silent_assassin": ["stare_down_rival", "train_in_silence", "attack_rival"],
+    "cult_leader": ["recruit_follower", "deliver_sermon", "manipulate_rival"],
+    "comedy_act": ["prank_rival", "cut_funny_promo", "befriend_underdog"],
+    "anti_hero": ["confront_authority", "reluctant_alliance", "lone_wolf_challenge"],
+    "legacy": ["honor_family_name", "prove_worth", "challenge_champion"],
+    "patriot": ["rally_crowd", "defend_partner", "challenge_foreign_heel"],
+    "daredevil": ["propose_dangerous_match", "cliff_dive_promo", "challenge_anyone"],
+}
+
+FALLBACK_REACTIONS = {
+    "win": [
+        "celebrates the victory",
+        "calls out their next challenger",
+        "dedicates the win to the fans",
+    ],
+    "loss": [
+        "vows revenge on their opponent",
+        "questions the referee's competence",
+        "retreats to regroup and train harder",
+    ],
+    "betrayal": [
+        "is FURIOUS and demands answers",
+        "swears vengeance on the traitor",
+        "questions everything they believed about loyalty",
+    ],
+    "title_win": [
+        "holds the championship high with tears in their eyes",
+        "declares a new era has begun",
+        "points to the crowd and says 'THIS is for YOU!'",
+    ],
+    "title_loss": [
+        "demands an immediate rematch",
+        "sits in stunned silence in the ring",
+        "snaps and attacks the new champion",
+    ],
+    "injury_return": [
+        "announces they're back and better than ever",
+        "warns everyone that time off made them hungrier",
+        "calls out whoever injured them",
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Core character functions
+# ---------------------------------------------------------------------------
+
+def character_decide(db: Session, wrestler_id: str,
+                     situation: str, options: List[str] = None) -> Dict[str, Any]:
+    """LLM-as-wrestler makes a decision about what to do next.
+
+    Args:
+        db: Database session
+        wrestler_id: The wrestler making the decision
+        situation: Description of the current situation
+        options: Optional list of valid choices
+
+    Returns:
+        Dict with 'action' (string) and 'reasoning' (string)
+    """
+    from models.game_models import GameWrestlerDB, GimmickHistoryDB
+
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == wrestler_id
+    ).first()
+    if not wrestler:
+        return {"action": "noop", "reasoning": "Wrestler not found"}
+
+    gimmick = db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler_id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+    archetype = gimmick.archetype if gimmick else "anti_hero"
+
+    # Template fallback
+    fallback_actions = FALLBACK_DECISIONS.get(archetype, FALLBACK_DECISIONS["anti_hero"])
+    fallback_action = random.choice(fallback_actions)
+    fallback = {"action": fallback_action, "reasoning": f"{wrestler.name} acts on instinct."}
+
+    if not USE_LLM:
+        return fallback
+
+    system_prompt = build_character_system_prompt(db, wrestler_id)
+    options_str = ""
+    if options:
+        options_str = f"\n\nYour options are: {', '.join(options)}. Pick ONE."
+
+    user_prompt = (
+        f"Situation: {situation}{options_str}\n\n"
+        f"What do you do? Respond in this exact format:\n"
+        f"ACTION: <your choice>\n"
+        f"REASONING: <1 sentence why, in character>"
+    )
+
+    result = _llm_call(system_prompt, user_prompt, "", max_tokens=100)
+    if not result:
+        return fallback
+
+    # Parse the response
+    action = fallback_action
+    reasoning = f"{wrestler.name} acts on instinct."
+    for line in result.split("\n"):
+        line = line.strip()
+        if line.upper().startswith("ACTION:"):
+            action = line.split(":", 1)[1].strip().lower().replace(" ", "_")
+        elif line.upper().startswith("REASONING:"):
+            reasoning = line.split(":", 1)[1].strip()
+
+    return {"action": action, "reasoning": reasoning}
+
+
+def character_speak(db: Session, wrestler_id: str,
+                    context: str, tone: str = "default") -> str:
+    """LLM-as-wrestler generates in-character speech.
+
+    Used for promos, social media posts, interview responses, etc.
+    The LLM speaks AS the character, not about them.
+    """
+    from models.game_models import GameWrestlerDB, GimmickHistoryDB
+    from game_service.promo_service import (
+        ARCHETYPE_OPENERS, ARCHETYPE_BODIES, ARCHETYPE_CLOSERS,
+    )
+
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == wrestler_id
+    ).first()
+    if not wrestler:
+        return "..."
+
+    gimmick = db.query(GimmickHistoryDB).filter(
+        GimmickHistoryDB.wrestler_id == wrestler_id,
+        GimmickHistoryDB.is_active == True,
+    ).first()
+    archetype = gimmick.archetype if gimmick else "anti_hero"
+
+    # Template fallback: stitch together archetype templates
+    openers = ARCHETYPE_OPENERS.get(archetype, ["..."])
+    bodies = ARCHETYPE_BODIES.get(archetype, ["..."])
+    closers = ARCHETYPE_CLOSERS.get(archetype, ["..."])
+    fallback = f"{random.choice(openers)} {random.choice(bodies)} {random.choice(closers)}"
+
+    if not USE_LLM:
+        return fallback
+
+    system_prompt = build_character_system_prompt(db, wrestler_id)
+    tone_instruction = ""
+    if tone == "angry":
+        tone_instruction = " You are FURIOUS right now."
+    elif tone == "triumphant":
+        tone_instruction = " You are riding high on victory."
+    elif tone == "desperate":
+        tone_instruction = " You are at your lowest point and fighting to stay relevant."
+    elif tone == "cocky":
+        tone_instruction = " You are supremely confident."
+    elif tone == "emotional":
+        tone_instruction = " You are overwhelmed with genuine emotion."
+
+    user_prompt = (
+        f"Context: {context}{tone_instruction}\n\n"
+        f"Speak IN CHARACTER as {wrestler.name}. "
+        f"This is a wrestling promo/speech. 3-5 sentences. "
+        f"No stage directions, just your words."
+    )
+
+    return _llm_call(system_prompt, user_prompt, fallback, max_tokens=200)
+
+
+def character_react(db: Session, wrestler_id: str,
+                    event_type: str, event_details: str = "") -> str:
+    """LLM-as-wrestler reacts to a specific event.
+
+    Returns a narrative description of how the character responds.
+    """
+    from models.game_models import GameWrestlerDB
+
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == wrestler_id
+    ).first()
+    if not wrestler:
+        return ""
+
+    # Template fallback
+    reactions = FALLBACK_REACTIONS.get(event_type, FALLBACK_REACTIONS["win"])
+    fallback = f"{wrestler.name} {random.choice(reactions)}"
+
+    if not USE_LLM:
+        return fallback
+
+    system_prompt = build_character_system_prompt(db, wrestler_id)
+    user_prompt = (
+        f"You just experienced: {event_type}. {event_details}\n\n"
+        f"Describe how {wrestler.name} reacts, in third person. "
+        f"1-2 sentences. Stay true to the character."
+    )
+
+    return _llm_call(system_prompt, user_prompt, fallback, max_tokens=100)
+
+
+def character_social_media_post(db: Session, wrestler_id: str,
+                                platform: str, post_type: str,
+                                recent_event: str = "") -> str:
+    """LLM-as-wrestler writes a social media post in character.
+
+    Different from character_speak — this is a social post, shorter,
+    more casual, platform-appropriate.
+    """
+    from models.game_models import GameWrestlerDB, GimmickHistoryDB
+
+    wrestler = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.id == wrestler_id
+    ).first()
+    if not wrestler:
+        return "..."
+
+    # Fallback handled by caller (social_media_service templates)
+    if not USE_LLM:
+        return ""  # Empty string signals caller to use its own templates
+
+    system_prompt = build_character_system_prompt(db, wrestler_id)
+
+    platform_note = {
+        "twitter": "Keep it under 280 characters. Punchy.",
+        "instagram": "Caption for a photo post. Can be slightly longer.",
+        "tiktok": "Caption for a short video. Casual, trendy.",
+        "youtube": "Title/description for a video. Slightly more formal.",
+    }.get(platform, "Keep it short.")
+
+    type_note = {
+        "kayfabe": "Stay fully in character. This is part of your wrestling persona.",
+        "shoot": "This is the REAL you behind the character. Authentic, personal.",
+        "worked_shoot": "Blur the lines. Hint at real frustration through the character.",
+        "personal": "Share something from your personal life. Warm, human.",
+    }.get(post_type, "Stay in character.")
+
+    event_context = f" Recent event: {recent_event}" if recent_event else ""
+
+    user_prompt = (
+        f"Write a {platform} post as {wrestler.name}. "
+        f"{type_note} {platform_note}{event_context}\n\n"
+        f"Just the post text, nothing else. No quotation marks."
+    )
+
+    return _llm_call(system_prompt, user_prompt, "", max_tokens=80)
+
+
+# ---------------------------------------------------------------------------
+# Booker AI: LLM as head booker making creative decisions
+# ---------------------------------------------------------------------------
+
+BOOKER_SYSTEM = (
+    "You are an experienced professional wrestling booker. "
+    "You think about long-term storytelling, crowd psychology, and building stars. "
+    "You balance giving fans what they want with surprising them. "
+    "You understand that the best feuds have personal stakes and clear motivations."
+)
+
+
+def booker_decide_storyline(db: Session, federation_id: str,
+                            wrestler1_name: str, wrestler2_name: str,
+                            context: str = "") -> Dict[str, str]:
+    """LLM-as-booker decides how to book a storyline between two wrestlers.
+
+    Returns dict with 'storyline_type', 'name', 'description', 'hook'.
+    """
+    from models.game_models import GameFederationDB
+
+    fed = db.query(GameFederationDB).filter(
+        GameFederationDB.id == federation_id
+    ).first()
+    fed_name = fed.name if fed else "the federation"
+    fed_style = getattr(fed, "booking_style", "sports_entertainment") if fed else "sports_entertainment"
+
+    # Template fallback
+    from game_service.storyline_service import STORYLINE_NAMES, FEUD_TRIGGERS
+    fallback_name = random.choice(STORYLINE_NAMES.get("feud", ["The Rivalry"]))
+    fallback_desc = random.choice(FEUD_TRIGGERS).format(w1=wrestler1_name, w2=wrestler2_name)
+    fallback = {
+        "storyline_type": "feud",
+        "name": fallback_name,
+        "description": fallback_desc,
+        "hook": f"{wrestler1_name} and {wrestler2_name} are on a collision course.",
+    }
+
+    if not USE_LLM:
+        return fallback
+
+    user_prompt = (
+        f"You are booking {fed_name} (style: {fed_style}). "
+        f"Create a storyline between {wrestler1_name} and {wrestler2_name}. "
+        f"{context}\n\n"
+        f"Respond in this exact format:\n"
+        f"TYPE: <feud|alliance|betrayal|championship_chase>\n"
+        f"NAME: <creative storyline name, 2-4 words>\n"
+        f"DESCRIPTION: <1 sentence setup>\n"
+        f"HOOK: <1 sentence that makes fans care>"
+    )
+
+    result = _llm_call(BOOKER_SYSTEM, user_prompt, "", max_tokens=150)
+    if not result:
+        return fallback
+
+    parsed = dict(fallback)
+    for line in result.split("\n"):
+        line = line.strip()
+        if line.upper().startswith("TYPE:"):
+            val = line.split(":", 1)[1].strip().lower()
+            if val in ("feud", "alliance", "betrayal", "championship_chase"):
+                parsed["storyline_type"] = val
+        elif line.upper().startswith("NAME:"):
+            parsed["name"] = line.split(":", 1)[1].strip()[:50]
+        elif line.upper().startswith("DESCRIPTION:"):
+            parsed["description"] = line.split(":", 1)[1].strip()
+        elif line.upper().startswith("HOOK:"):
+            parsed["hook"] = line.split(":", 1)[1].strip()
+
+    return parsed
+
+
+def booker_decide_finish(db: Session, federation_id: str,
+                         wrestler1_name: str, wrestler2_name: str,
+                         storyline_context: str = "",
+                         is_ppv: bool = False) -> Dict[str, str]:
+    """LLM-as-booker decides match finish and winner.
+
+    Returns dict with 'winner', 'finish_type', 'reasoning'.
+    """
+    fallback_winner = random.choice([wrestler1_name, wrestler2_name])
+    fallback = {
+        "winner": fallback_winner,
+        "finish_type": "pinfall",
+        "reasoning": "The better wrestler prevails.",
+    }
+
+    if not USE_LLM:
+        return fallback
+
+    ppv_note = " This is a PPV match — the finish needs to feel special." if is_ppv else ""
+
+    user_prompt = (
+        f"Book the finish for: {wrestler1_name} vs {wrestler2_name}. "
+        f"{storyline_context}{ppv_note}\n\n"
+        f"Respond in this exact format:\n"
+        f"WINNER: <{wrestler1_name} or {wrestler2_name}>\n"
+        f"FINISH: <pinfall|submission|dq|countout|ref_stoppage>\n"
+        f"REASONING: <1 sentence booking logic>"
+    )
+
+    result = _llm_call(BOOKER_SYSTEM, user_prompt, "", max_tokens=100)
+    if not result:
+        return fallback
+
+    parsed = dict(fallback)
+    for line in result.split("\n"):
+        line = line.strip()
+        if line.upper().startswith("WINNER:"):
+            name = line.split(":", 1)[1].strip()
+            if wrestler1_name.lower() in name.lower():
+                parsed["winner"] = wrestler1_name
+            elif wrestler2_name.lower() in name.lower():
+                parsed["winner"] = wrestler2_name
+        elif line.upper().startswith("FINISH:"):
+            val = line.split(":", 1)[1].strip().lower()
+            if val in ("pinfall", "submission", "dq", "countout", "ref_stoppage"):
+                parsed["finish_type"] = val
+        elif line.upper().startswith("REASONING:"):
+            parsed["reasoning"] = line.split(":", 1)[1].strip()
+
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# Match narrative: LLM generates a story-driven match summary
+# ---------------------------------------------------------------------------
+
+def generate_match_narrative(winner_name: str, loser_name: str,
+                             finish_type: str, finish_description: str,
+                             rating: float, key_spots: List[str],
+                             stipulation: str = "",
+                             is_title_match: bool = False) -> str:
+    """Generate an evocative match summary using the LLM.
+
+    Falls back to spot-based narrative when LLM is off.
+    """
+    # Template fallback: stitch key spots
+    fallback = " ".join(key_spots[-5:]) if key_spots else (
+        f"{winner_name} defeated {loser_name} via {finish_type}."
+    )
+
+    if not USE_LLM:
+        return fallback
+
+    stip_note = f" Stipulation: {stipulation}." if stipulation else ""
+    title_note = " This was a championship match." if is_title_match else ""
+    spots_summary = "; ".join(key_spots[-4:]) if key_spots else "a hard-fought contest"
+
+    user_prompt = (
+        f"Write a dramatic 2-3 sentence wrestling match summary.\n"
+        f"Winner: {winner_name}. Loser: {loser_name}. "
+        f"Finish: {finish_type} ({finish_description}). "
+        f"Rating: {rating:.1f}/5.0 stars.{stip_note}{title_note}\n"
+        f"Key moments: {spots_summary}\n\n"
+        f"Write like a wrestling journalist. Vivid, concise, dramatic."
+    )
+
+    system = (
+        "You are a veteran wrestling journalist writing match reports. "
+        "Capture the drama and emotion of the match in vivid prose. "
+        "Never use generic phrases. Make each summary feel unique."
+    )
+
+    return _llm_call(system, user_prompt, fallback, max_tokens=120)
+
+
+# ---------------------------------------------------------------------------
+# Character agency tick: wrestlers make autonomous decisions
+# ---------------------------------------------------------------------------
+
+def tick_character_agency(db: Session, world_id: str, game_date: str) -> List[str]:
+    """Daily character agency tick — LLM-driven wrestlers make decisions.
+
+    Each wrestler has a small chance per day to take an autonomous action:
+    - Call out a rival on social media
+    - Request a match
+    - Propose an alliance
+    - React to a recent event
+
+    Returns list of narrative events generated.
+    """
+    from models.game_models import (
+        GameWrestlerDB, GameNarrativeLogDB, StorylineDB,
+        StorylineParticipantDB, ContractDB,
+    )
+
+    events = []
+
+    # Only top wrestlers get character agency (limits LLM calls)
+    wrestlers = db.query(GameWrestlerDB).filter(
+        GameWrestlerDB.world_id == world_id,
+        GameWrestlerDB.is_active == True,
+        GameWrestlerDB.is_injured == False,
+        GameWrestlerDB.popularity >= 40,
+    ).all()
+
+    for wrestler in wrestlers:
+        # 5% chance per day for a character-driven action
+        if random.random() > 0.05:
+            continue
+
+        # Gather context for the decision
+        storyline_parts = db.query(StorylineParticipantDB).filter(
+            StorylineParticipantDB.wrestler_id == wrestler.id,
+        ).all()
+        in_storyline = False
+        rival_name = None
+        for sp in storyline_parts:
+            sl = db.query(StorylineDB).filter(
+                StorylineDB.id == sp.storyline_id,
+                StorylineDB.status.in_(["active", "climax"]),
+            ).first()
+            if sl:
+                in_storyline = True
+                rival_part = db.query(StorylineParticipantDB).filter(
+                    StorylineParticipantDB.storyline_id == sl.id,
+                    StorylineParticipantDB.wrestler_id != wrestler.id,
+                ).first()
+                if rival_part:
+                    rival = db.query(GameWrestlerDB).filter(
+                        GameWrestlerDB.id == rival_part.wrestler_id
+                    ).first()
+                    if rival:
+                        rival_name = rival.name
+                break
+
+        # Build situation
+        if in_storyline and rival_name:
+            situation = (
+                f"You are in the middle of a feud with {rival_name}. "
+                f"Your popularity is {wrestler.popularity}/100, morale is {wrestler.morale}/100. "
+                f"What do you do to escalate or advance the situation?"
+            )
+            options = [
+                "call_out_rival", "demand_stipulation_match",
+                "attack_backstage", "cut_promo", "social_media_tirade",
+            ]
+        elif wrestler.popularity > 70:
+            situation = (
+                f"You are one of the top stars (popularity {wrestler.popularity}/100). "
+                f"You don't have an active feud right now. What do you do?"
+            )
+            options = [
+                "issue_open_challenge", "demand_title_shot",
+                "call_out_specific_rival", "cut_promo", "mentor_young_talent",
+            ]
+        else:
+            situation = (
+                f"You are trying to climb the ranks (popularity {wrestler.popularity}/100). "
+                f"You need to make a name for yourself. What do you do?"
+            )
+            options = [
+                "challenge_someone_above", "cut_passionate_promo",
+                "create_viral_moment", "train_and_improve", "form_alliance",
+            ]
+
+        decision = character_decide(db, wrestler.id, situation, options)
+        action = decision["action"]
+        reasoning = decision["reasoning"]
+
+        # Log the character-driven event
+        event_desc = f"{wrestler.name}: {action.replace('_', ' ')} — {reasoning}"
+        events.append(event_desc)
+
+        db.add(GameNarrativeLogDB(
+            world_id=world_id,
+            game_date=game_date,
+            tick=0,
+            event_type="character_agency",
+            description=event_desc,
+            involved_entities=[wrestler.id],
+            importance=5,
+        ))
+
+        # Some actions have mechanical effects
+        if action in ("call_out_rival", "social_media_tirade") and rival_name:
+            # Boost storyline heat
+            for sp in storyline_parts:
+                sl = db.query(StorylineDB).filter(
+                    StorylineDB.id == sp.storyline_id,
+                    StorylineDB.status.in_(["active", "climax"]),
+                ).first()
+                if sl:
+                    sl.heat = min(100, sl.heat + random.randint(2, 5))
+                    break
+        elif action in ("cut_promo", "cut_passionate_promo"):
+            wrestler.popularity = min(100, wrestler.popularity + random.randint(1, 3))
+        elif action == "train_and_improve":
+            wrestler.condition = min(100, wrestler.condition + 5)
+        elif action in ("challenge_someone_above", "issue_open_challenge", "demand_title_shot"):
+            wrestler.popularity = min(100, wrestler.popularity + random.randint(1, 2))
+
+    return events

--- a/game_service/promo_service.py
+++ b/game_service/promo_service.py
@@ -422,32 +422,30 @@ def _generate_persona_promo(wrestler, stats, target_id, db, promo_type):
     """
     gimmick = _get_current_gimmick(db, wrestler.id)
 
-    # Try LLM-enhanced promo generation if enabled
+    # LLM-as-character: the wrestler speaks for themselves
     import os
     if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
-        template_fallback = None  # Will be generated below if needed
         try:
-            from llm_abstraction.provider import get_llm
-            archetype = gimmick.archetype if gimmick else "anti_hero"
-            alignment = wrestler.alignment or "face"
+            from game_service.character_agent import character_speak
             target_name = ""
             if target_id:
                 target = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == target_id).first()
                 target_name = target.name if target else ""
 
-            prompt = (
-                f"Write a short wrestling promo (3-4 sentences) for {wrestler.name}, "
-                f"a {alignment} with a {archetype} gimmick. "
-                f"{'They are calling out their rival ' + target_name + '. ' if target_name else ''}"
-                f"Match the tone to the archetype. Keep it dramatic and in-character."
-            )
-            response = get_llm().generate(
-                prompt,
-                system_message="You are a wrestling promo writer. Write in-character promos only.",
-                max_tokens=150,
-            )
-            if response and response.content and len(response.content.strip()) > 20:
-                return response.content.strip()
+            # Build context that tells the character what the promo situation is
+            context = f"You are cutting a {promo_type} promo in the ring."
+            if target_name:
+                context += f" You are calling out {target_name}."
+            if wrestler.morale < 30:
+                tone = "desperate"
+            elif wrestler.popularity > 80:
+                tone = "cocky"
+            else:
+                tone = "default"
+
+            result = character_speak(db, wrestler.id, context, tone=tone)
+            if result and len(result.strip()) > 20:
+                return result
         except Exception:
             pass  # Fall through to template system
 

--- a/game_service/promo_service.py
+++ b/game_service/promo_service.py
@@ -418,9 +418,38 @@ def _determine_emotional_state(life_events, kayfabe_commitment):
 def _generate_persona_promo(wrestler, stats, target_id, db, promo_type):
     """Generate a promo using the persona duality system.
 
-    Priority: archetype voice > emotional state > alignment fallback.
+    Priority: LLM (if enabled) > archetype voice > emotional state > alignment fallback.
     """
     gimmick = _get_current_gimmick(db, wrestler.id)
+
+    # Try LLM-enhanced promo generation if enabled
+    import os
+    if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
+        template_fallback = None  # Will be generated below if needed
+        try:
+            from llm_abstraction.provider import get_llm
+            archetype = gimmick.archetype if gimmick else "anti_hero"
+            alignment = wrestler.alignment or "face"
+            target_name = ""
+            if target_id:
+                target = db.query(GameWrestlerDB).filter(GameWrestlerDB.id == target_id).first()
+                target_name = target.name if target else ""
+
+            prompt = (
+                f"Write a short wrestling promo (3-4 sentences) for {wrestler.name}, "
+                f"a {alignment} with a {archetype} gimmick. "
+                f"{'They are calling out their rival ' + target_name + '. ' if target_name else ''}"
+                f"Match the tone to the archetype. Keep it dramatic and in-character."
+            )
+            response = get_llm().generate(
+                prompt,
+                system_message="You are a wrestling promo writer. Write in-character promos only.",
+                max_tokens=150,
+            )
+            if response and response.content and len(response.content.strip()) > 20:
+                return response.content.strip()
+        except Exception:
+            pass  # Fall through to template system
 
     # If no gimmick data, fall back to legacy system
     if not gimmick or gimmick.archetype not in ARCHETYPE_OPENERS:

--- a/game_service/show_service.py
+++ b/game_service/show_service.py
@@ -270,6 +270,55 @@ def npc_book_card(db: Session, show: ShowDB, ppv_event=None, next_ppv=None) -> l
     segments = []
     used = set()
 
+    # Storyline-aware booking: feuding wrestlers should face each other
+    from models.game_models import StorylineDB, StorylineParticipantDB
+    active_storylines = db.query(StorylineDB).filter(
+        StorylineDB.federation_id == fed.id,
+        StorylineDB.status.in_(["active", "climax"]),
+    ).order_by(StorylineDB.heat.desc()).all()
+
+    storyline_matches_booked = 0
+    for sl in active_storylines:
+        if storyline_matches_booked >= 2:
+            break  # Max 2 storyline matches per weekly show
+        parts = db.query(StorylineParticipantDB).filter(
+            StorylineParticipantDB.storyline_id == sl.id,
+        ).all()
+        sl_wrestler_ids = [p.wrestler_id for p in parts]
+        # Find available pairs from the storyline
+        available = [wid for wid in sl_wrestler_ids
+                     if wid in wrestler_ids and wid not in used]
+        if len(available) >= 2:
+            w1_id, w2_id = available[0], available[1]
+            w1 = next((w for w in wrestlers if w.id == w1_id), None)
+            w2 = next((w for w in wrestlers if w.id == w2_id), None)
+            if w1 and w2 and not w1.is_injured and not w2.is_injured:
+                # Higher-heat storyline gets higher card position
+                is_main = (storyline_matches_booked == 0 and sl.heat >= 70)
+                w1_push = push_map.get(w1.id)
+                w2_push = push_map.get(w2.id)
+                w1_rank = PUSH_TIERS.index(w1_push.push_tier) if w1_push and w1_push.push_tier in PUSH_TIERS else 2
+                w2_rank = PUSH_TIERS.index(w2_push.push_tier) if w2_push and w2_push.push_tier in PUSH_TIERS else 2
+                planned_winner = w1 if w1_rank <= w2_rank else w2
+                # Climax storylines get gimmick finishes
+                finish = "pinfall"
+                stipulation = None
+                if sl.status == "climax" and random.random() < 0.4:
+                    stipulation = random.choice(["No DQ", "Steel Cage", "Last Man Standing"])
+
+                seg = book_match(
+                    db, show.id, show.world_id,
+                    wrestler_ids=[w1.id, w2.id],
+                    match_type="singles",
+                    stipulation=stipulation,
+                    planned_winner_id=planned_winner.id,
+                    planned_finish=finish,
+                )
+                segments.append(seg)
+                used.add(w1.id)
+                used.add(w2.id)
+                storyline_matches_booked += 1
+
     # Check for tag teams — book a tag match if available (30% chance)
     tag_teams = db.query(TagTeamDB).filter(
         TagTeamDB.world_id == show.world_id,
@@ -355,7 +404,14 @@ def npc_book_card(db: Session, show: ShowDB, ppv_event=None, next_ppv=None) -> l
                 "No DQ", "Falls Count Anywhere", "Street Fight", "Extreme Rules"
             ])
 
-        finish = random.choice(["pinfall", "pinfall", "pinfall", "submission"])
+        finish = random.choices(
+            ["pinfall", "submission", "count_out", "disqualification"],
+            weights=[60, 15, 10, 15],
+            k=1,
+        )[0]
+        # Title matches almost always end clean
+        if is_title and finish in ("count_out", "disqualification"):
+            finish = "pinfall"
         position = actual_pos + 1
 
         seg = book_match(

--- a/game_service/show_service.py
+++ b/game_service/show_service.py
@@ -301,16 +301,34 @@ def npc_book_card(db: Session, show: ShowDB, ppv_event=None, next_ppv=None) -> l
                 w1_rank = PUSH_TIERS.index(w1_push.push_tier) if w1_push and w1_push.push_tier in PUSH_TIERS else 2
                 w2_rank = PUSH_TIERS.index(w2_push.push_tier) if w2_push and w2_push.push_tier in PUSH_TIERS else 2
                 planned_winner = w1 if w1_rank <= w2_rank else w2
-                # Climax storylines get gimmick finishes
+                # Climax storylines get gimmick finishes — more variety
                 finish = "pinfall"
                 stipulation = None
-                if sl.status == "climax" and random.random() < 0.4:
-                    stipulation = random.choice(["No DQ", "Steel Cage", "Last Man Standing"])
+                match_type = "singles"
+                if sl.status == "climax" and random.random() < 0.5:
+                    gimmick_choice = random.choices(
+                        ["Steel Cage", "Ladder", "Tables", "Hell in a Cell",
+                         "No DQ", "Last Man Standing", "Iron Man"],
+                        weights=[20, 15, 15, 10, 20, 15, 5], k=1,
+                    )[0]
+                    stipulation = gimmick_choice
+                    if gimmick_choice == "Steel Cage":
+                        match_type = "cage"
+                    elif gimmick_choice == "Ladder":
+                        match_type = "ladder"
+                        finish = "stipulation"
+                    elif gimmick_choice == "Tables":
+                        match_type = "tables"
+                        finish = "stipulation"
+                    elif gimmick_choice == "Hell in a Cell":
+                        match_type = "hell_in_a_cell"
+                    elif gimmick_choice == "Iron Man":
+                        match_type = "iron_man"
 
                 seg = book_match(
                     db, show.id, show.world_id,
                     wrestler_ids=[w1.id, w2.id],
-                    match_type="singles",
+                    match_type=match_type,
                     stipulation=stipulation,
                     planned_winner_id=planned_winner.id,
                     planned_finish=finish,
@@ -497,11 +515,12 @@ def npc_book_card(db: Session, show: ShowDB, ppv_event=None, next_ppv=None) -> l
                 is_title = True
                 champ_id = champ.id
 
-        # Hardcore booking style adds stipulations
+        # Hardcore booking style adds stipulations and gimmick matches
         stipulation = None
         if booking_style == "hardcore" and random.random() < 0.4:
             stipulation = random.choice([
-                "No DQ", "Falls Count Anywhere", "Street Fight", "Extreme Rules"
+                "No DQ", "Falls Count Anywhere", "Street Fight", "Extreme Rules",
+                "Tables", "Steel Cage", "Ladder",
             ])
 
         finish = random.choices(

--- a/game_service/show_service.py
+++ b/game_service/show_service.py
@@ -17,6 +17,7 @@ from models.game_models import (
     ShowDB, ShowSegmentDB, MatchDB, MatchParticipantDB,
     GameFederationDB, GameWrestlerDB, WrestlerStatsDB,
     ContractDB, ChampionshipDB, TagTeamDB, PromoDB,
+    WorldDB,
 )
 
 logger = logging.getLogger(__name__)
@@ -354,6 +355,71 @@ def npc_book_card(db: Session, show: ShowDB, ppv_event=None, next_ppv=None) -> l
                 used.add(wid)
             booked_tag = True
 
+    # --- Player match requests and dark matches ---
+    # Check if any player wrestler on this roster has a pending match request
+    world = db.query(WorldDB).filter(WorldDB.id == show.world_id).first()
+    player_match_booked = False
+    if world and world.world_config:
+        pending_requests = (world.world_config or {}).get("pending_match_requests", [])
+        for req in list(pending_requests):
+            if req.get("federation_id") != fed.id:
+                continue
+            pw_id = req.get("wrestler_id")
+            pw = next((w for w in wrestlers if w.id == pw_id and w.id not in used), None)
+            if not pw:
+                continue
+
+            if req.get("type") == "open_challenge" and req.get("opponent_id"):
+                opp = next((w for w in wrestlers if w.id == req["opponent_id"] and w.id not in used), None)
+            else:
+                # Pick a random opponent close in popularity
+                candidates = [w for w in wrestlers if w.id not in used and w.id != pw_id and not w.is_injured]
+                opp = random.choice(candidates) if candidates else None
+
+            if opp:
+                seg = book_match(
+                    db, show.id, show.world_id,
+                    wrestler_ids=[pw.id, opp.id],
+                    match_type="singles",
+                    planned_winner_id=pw.id if random.random() < 0.50 else opp.id,
+                    planned_finish="pinfall",
+                    position=1,  # Opening match — gets the player on TV
+                )
+                segments.append(seg)
+                used.add(pw.id)
+                used.add(opp.id)
+                player_match_booked = True
+
+            # Remove fulfilled request
+            pending_requests = [r for r in pending_requests if r.get("wrestler_id") != pw_id]
+            break  # One player match per show
+
+        # Update metadata
+        meta = world.world_config or {}
+        meta["pending_match_requests"] = pending_requests
+        world.world_config = meta
+
+    # Dark match: if any player wrestler (is_npc=False) is on the roster
+    # and hasn't been booked this show, give them a dark match for exposure
+    if not player_match_booked:
+        for w in wrestlers:
+            if not w.is_npc and w.id not in used and not w.is_injured:
+                candidates = [o for o in wrestlers if o.id not in used and o.id != w.id and not o.is_injured]
+                if candidates:
+                    opp = random.choice(candidates)
+                    seg = book_match(
+                        db, show.id, show.world_id,
+                        wrestler_ids=[w.id, opp.id],
+                        match_type="singles",
+                        planned_winner_id=w.id if random.random() < 0.55 else opp.id,
+                        planned_finish="pinfall",
+                        position=0,  # Dark match — position 0, before the card
+                    )
+                    segments.append(seg)
+                    used.add(w.id)
+                    used.add(opp.id)
+                break  # One dark match max
+
     num_matches = min(len(wrestlers) // 2, len(CARD_POSITIONS))
     if booked_tag:
         num_matches = max(1, num_matches - 1)  # Already booked one
@@ -363,10 +429,45 @@ def npc_book_card(db: Session, show: ShowDB, ppv_event=None, next_ppv=None) -> l
     # Put lower-ranked first (they'll be openers), higher-ranked last (main event)
     match_wrestlers.reverse()
 
+    triple_threat_booked = False
     for i in range(num_matches):
         available = [w for w in match_wrestlers if w.id not in used]
         if len(available) < 2:
             break
+
+        # 15% chance for a triple threat on weekly TV (once per show, not main event)
+        actual_pos = i + (1 if booked_tag else 0)
+        is_main_event_slot = (actual_pos == num_matches + (1 if booked_tag else 0) - 1)
+        match_type = "singles"
+        if (not triple_threat_booked and not is_main_event_slot
+                and len(available) >= 3 and random.random() < 0.15):
+            w1, w2, w3 = available[0], available[1], available[2]
+            used.add(w1.id)
+            used.add(w2.id)
+            used.add(w3.id)
+            match_type = "triple_threat"
+            triple_threat_booked = True
+            # Winner is the highest-pushed of the three
+            all_w = [w1, w2, w3]
+            scores = {}
+            for w in all_w:
+                wp = push_map.get(w.id)
+                tier_rank = PUSH_TIERS.index(wp.push_tier) if wp and wp.push_tier in PUSH_TIERS else 2
+                scores[w.id] = (5 - tier_rank) * 20 + w.popularity + random.randint(-15, 15)
+                if wp and wp.protected:
+                    scores[w.id] += 30
+            planned_winner = max(all_w, key=lambda w: scores[w.id])
+            position = actual_pos + 1
+            seg = book_match(
+                db, show.id, show.world_id,
+                wrestler_ids=[w1.id, w2.id, w3.id],
+                match_type=match_type,
+                planned_winner_id=planned_winner.id,
+                planned_finish="pinfall",
+                position=position,
+            )
+            segments.append(seg)
+            continue
 
         w1, w2 = available[0], available[1]
         used.add(w1.id)
@@ -390,8 +491,7 @@ def npc_book_card(db: Session, show: ShowDB, ppv_event=None, next_ppv=None) -> l
         # Title match for main event if champion is available
         is_title = False
         champ_id = None
-        actual_pos = i + (1 if booked_tag else 0)
-        if actual_pos == num_matches + (1 if booked_tag else 0) - 1 and championships:
+        if is_main_event_slot and championships:
             champ = championships[0]
             if champ.current_holder_id in (w1.id, w2.id):
                 is_title = True
@@ -548,8 +648,51 @@ def _book_ppv_card(db, show, fed, ppv_event, wrestlers, championships, push_map,
         segments.append(seg)
         position += 1
 
-    # Fill remaining slots with available wrestlers
-    remaining = [w for w in wrestlers if w.id not in used]
+    # Multi-person match for PPVs — fatal four way or battle royal
+    remaining = [w for w in wrestlers if w.id not in used and not w.is_injured]
+
+    is_crown_jewel = getattr(ppv_event, 'is_crown_jewel', False)
+    if is_crown_jewel and len(remaining) >= 6:
+        # Crown Jewel battle royal with 6-10 participants
+        br_count = min(len(remaining), 10)
+        br_wrestlers = remaining[:br_count]
+        br_ids = [w.id for w in br_wrestlers]
+        for wid in br_ids:
+            used.add(wid)
+        # Winner is most popular
+        winner = max(br_wrestlers, key=lambda w: w.popularity + random.randint(-10, 10))
+        seg = book_match(
+            db, show.id, show.world_id,
+            wrestler_ids=br_ids,
+            match_type="battle_royal",
+            planned_winner_id=winner.id,
+            planned_finish="last_person_standing",
+            position=position,
+        )
+        segments.append(seg)
+        position += 1
+        remaining = [w for w in remaining if w.id not in used]
+    elif len(remaining) >= 4:
+        # Fatal four way on non-crown-jewel PPVs (60% chance)
+        if random.random() < 0.60:
+            ffw = remaining[:4]
+            ffw_ids = [w.id for w in ffw]
+            for wid in ffw_ids:
+                used.add(wid)
+            winner = max(ffw, key=lambda w: w.popularity + random.randint(-10, 10))
+            seg = book_match(
+                db, show.id, show.world_id,
+                wrestler_ids=ffw_ids,
+                match_type="fatal_four_way",
+                planned_winner_id=winner.id,
+                planned_finish="pinfall",
+                position=position,
+            )
+            segments.append(seg)
+            position += 1
+            remaining = [w for w in remaining if w.id not in used]
+
+    # Fill remaining slots with singles matches
     for i in range(0, min(len(remaining) - 1, 4), 2):
         w1, w2 = remaining[i], remaining[i + 1]
         used.add(w1.id)

--- a/game_service/social_media_service.py
+++ b/game_service/social_media_service.py
@@ -5,6 +5,7 @@ Generates in-character, shoot, and worked-shoot posts. Handles viral moments,
 feud exchanges, and fan engagement tracking.
 """
 
+import os
 import random
 import logging
 from sqlalchemy.orm import Session
@@ -119,7 +120,7 @@ def generate_social_post(db: Session, wrestler_id: str, world_id: str,
         post_type = "worked_shoot"
 
     # Generate content
-    content = _generate_post_content(wrestler, gimmick, backstory, post_type)
+    content = _generate_post_content(wrestler, gimmick, backstory, post_type, db=db)
 
     # Platform selection
     platform = random.choices(
@@ -187,7 +188,7 @@ def generate_social_post(db: Session, wrestler_id: str, world_id: str,
     return post
 
 
-def _generate_post_content(wrestler, gimmick, backstory, post_type):
+def _generate_post_content(wrestler, gimmick, backstory, post_type, db=None):
     """Generate post content based on type and persona."""
     hometown = wrestler.hometown or "the road"
 
@@ -207,21 +208,19 @@ def _generate_post_content(wrestler, gimmick, backstory, post_type):
     else:
         fallback = "..."
 
-    # Try LLM-enhanced post if enabled
+    # LLM-as-character: the wrestler posts as themselves
     import os
-    if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
+    if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes") and db:
         try:
-            from llm_abstraction.provider import get_llm
-            archetype = gimmick.archetype if gimmick else "wrestler"
-            prompt = (
-                f"Write a short social media post (1-2 sentences, under 280 chars) "
-                f"for {wrestler.name}, a {wrestler.alignment or 'face'} wrestler "
-                f"with a {archetype} persona. Post type: {post_type}. "
-                f"No hashtags unless it fits the character."
+            from game_service.character_agent import character_social_media_post
+            result = character_social_media_post(
+                db=db,
+                wrestler_id=wrestler.id,
+                platform="twitter",
+                post_type=post_type,
             )
-            response = get_llm().generate(prompt, max_tokens=80)
-            if response and response.content and len(response.content.strip()) > 10:
-                return response.content.strip()
+            if result and len(result.strip()) > 10:
+                return result
         except Exception:
             pass
 
@@ -412,8 +411,19 @@ def generate_feud_exchange(db: Session, wrestler1_id: str, wrestler2_id: str,
     posts = []
     platform = random.choice(["twitter", "twitter", "instagram"])
 
-    # First salvo
+    # First salvo — LLM-as-character or template
     content1 = random.choice(CHALLENGE_POSTS).format(target=w2.name)
+    if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
+        try:
+            from game_service.character_agent import character_social_media_post
+            llm_content = character_social_media_post(
+                db, w1.id, platform, "kayfabe",
+                recent_event=f"feuding with {w2.name}",
+            )
+            if llm_content and len(llm_content.strip()) > 10:
+                content1 = llm_content
+        except Exception:
+            pass
     post1 = SocialMediaPostDB(
         wrestler_id=w1.id, world_id=world_id, game_date=game_date,
         content=content1, post_type="kayfabe", platform=platform,
@@ -425,8 +435,19 @@ def generate_feud_exchange(db: Session, wrestler1_id: str, wrestler2_id: str,
     db.add(post1)
     posts.append(post1)
 
-    # Response
+    # Response — LLM-as-character or template
     content2 = random.choice(RESPONSE_POSTS).format(target=w1.name)
+    if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
+        try:
+            from game_service.character_agent import character_social_media_post
+            llm_content = character_social_media_post(
+                db, w2.id, platform, "kayfabe",
+                recent_event=f"responding to {w1.name}'s callout",
+            )
+            if llm_content and len(llm_content.strip()) > 10:
+                content2 = llm_content
+        except Exception:
+            pass
     post2 = SocialMediaPostDB(
         wrestler_id=w2.id, world_id=world_id, game_date=game_date,
         content=content2, post_type="kayfabe", platform=platform,

--- a/game_service/social_media_service.py
+++ b/game_service/social_media_service.py
@@ -191,18 +191,41 @@ def _generate_post_content(wrestler, gimmick, backstory, post_type):
     """Generate post content based on type and persona."""
     hometown = wrestler.hometown or "the road"
 
+    # Template-based fallback
     if post_type == "kayfabe":
         if wrestler.alignment == "heel":
-            return random.choice(KAYFABE_HEEL_POSTS)
-        return random.choice(KAYFABE_FACE_POSTS)
+            fallback = random.choice(KAYFABE_HEEL_POSTS)
+        else:
+            fallback = random.choice(KAYFABE_FACE_POSTS)
     elif post_type == "shoot":
         template = random.choice(SHOOT_POSTS)
-        return template.format(hometown=hometown)
+        fallback = template.format(hometown=hometown)
     elif post_type == "worked_shoot":
-        return random.choice(WORKED_SHOOT_POSTS)
+        fallback = random.choice(WORKED_SHOOT_POSTS)
     elif post_type == "personal":
-        return random.choice(PERSONAL_POSTS)
-    return "..."
+        fallback = random.choice(PERSONAL_POSTS)
+    else:
+        fallback = "..."
+
+    # Try LLM-enhanced post if enabled
+    import os
+    if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
+        try:
+            from llm_abstraction.provider import get_llm
+            archetype = gimmick.archetype if gimmick else "wrestler"
+            prompt = (
+                f"Write a short social media post (1-2 sentences, under 280 chars) "
+                f"for {wrestler.name}, a {wrestler.alignment or 'face'} wrestler "
+                f"with a {archetype} persona. Post type: {post_type}. "
+                f"No hashtags unless it fits the character."
+            )
+            response = get_llm().generate(prompt, max_tokens=80)
+            if response and response.content and len(response.content.strip()) > 10:
+                return response.content.strip()
+        except Exception:
+            pass
+
+    return fallback
 
 
 # ---------------------------------------------------------------------------
@@ -278,7 +301,13 @@ def check_viral_moment(post: SocialMediaPostDB) -> bool:
 
 
 def process_viral_fallout(db: Session, post: SocialMediaPostDB, game_date: str):
-    """Handle the effects of a viral post."""
+    """Handle the effects of a viral post.
+
+    Viral posts now feed back into the gameplay loop:
+    - Popularity changes (existing)
+    - Storyline heat boosts when the post involves a rival
+    - Narrative log events for high-controversy viral moments
+    """
     wrestler = db.query(GameWrestlerDB).filter(
         GameWrestlerDB.id == post.wrestler_id,
     ).first()
@@ -296,6 +325,38 @@ def process_viral_fallout(db: Session, post: SocialMediaPostDB, game_date: str):
     wrestler.social_media_following = (wrestler.social_media_following or 1000) + random.randint(500, 5000)
     post.popularity_impact = pop_change
 
+    # --- NEW: Storyline heat boost from viral posts ---
+    # If the wrestler is in an active storyline, viral buzz heats the feud
+    storyline_participants = db.query(StorylineParticipantDB).filter(
+        StorylineParticipantDB.wrestler_id == wrestler.id,
+    ).all()
+    for sp in storyline_participants:
+        storyline = db.query(StorylineDB).filter(
+            StorylineDB.id == sp.storyline_id,
+            StorylineDB.status.in_(["active", "climax", "brewing"]),
+        ).first()
+        if storyline:
+            heat_boost = random.randint(3, 5)
+            if post.controversy_level >= 40:
+                heat_boost += 2
+            storyline.heat = min(100, storyline.heat + heat_boost)
+            logger.info("Viral post boosted storyline %s heat by +%d to %d",
+                        storyline.id[:8], heat_boost, storyline.heat)
+
+    # --- NEW: Narrative log for high-controversy viral moments ---
+    if post.controversy_level >= 7:
+        from models.game_models import GameNarrativeLogDB
+        db.add(GameNarrativeLogDB(
+            world_id=post.world_id,
+            game_date=game_date,
+            tick=0,
+            event_type="social_media_viral",
+            description=f"{wrestler.name}'s viral post is causing a stir backstage! "
+                        f"(controversy: {post.controversy_level}, engagement: {post.engagement_score})",
+            involved_entities=[wrestler.id],
+            importance=6,
+        ))
+
     # Generate news
     try:
         from game_service.news_service import generate_social_media_news
@@ -304,6 +365,35 @@ def process_viral_fallout(db: Session, post: SocialMediaPostDB, game_date: str):
         logger.warning("Failed to generate social media news: %s", e)
 
     logger.info("Viral post by %s! Pop change: %+d", wrestler.name, pop_change)
+
+
+# ---------------------------------------------------------------------------
+# Buzz bonus for card draw
+# ---------------------------------------------------------------------------
+
+def get_viral_buzz_bonus(db: Session, world_id: str, game_date: str,
+                         wrestler_ids: list) -> float:
+    """Return a card draw multiplier bonus based on recent viral posts.
+
+    Checks the last 7 game days for viral posts by wrestlers on the card.
+    Each viral post adds 0.1 to the bonus (capped at 0.5).
+    """
+    from datetime import datetime, timedelta
+    try:
+        current = datetime.strptime(game_date, "%Y-%m-%d")
+        week_ago = (current - timedelta(days=7)).strftime("%Y-%m-%d")
+    except (ValueError, TypeError):
+        return 0.0
+
+    viral_count = db.query(SocialMediaPostDB).filter(
+        SocialMediaPostDB.world_id == world_id,
+        SocialMediaPostDB.is_viral == True,
+        SocialMediaPostDB.game_date >= week_ago,
+        SocialMediaPostDB.game_date <= game_date,
+        SocialMediaPostDB.wrestler_id.in_(wrestler_ids),
+    ).count()
+
+    return min(0.5, viral_count * 0.1)
 
 
 # ---------------------------------------------------------------------------

--- a/game_service/storyline_service.py
+++ b/game_service/storyline_service.py
@@ -131,21 +131,26 @@ def create_storyline(db: Session, world_id: str, federation_id: str,
         else:
             description = f"A new {storyline_type} storyline unfolds."
 
-    # Try LLM-enhanced storyline description if enabled
+    # LLM-as-booker: the head booker AI crafts the storyline
     import os
     if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
         try:
-            from llm_abstraction.provider import get_llm
+            from game_service.character_agent import booker_decide_storyline
             names = [w_names.get(wid, "Unknown") for wid in wrestler_ids[:2]]
-            prompt = (
-                f"Write a 1-2 sentence wrestling storyline description for a {storyline_type} "
-                f"between {' and '.join(names)}. Make it dramatic and concise."
+            booker_result = booker_decide_storyline(
+                db, federation_id,
+                names[0] if names else "Unknown",
+                names[1] if len(names) > 1 else "Unknown",
+                context=f"Creating a {storyline_type} storyline.",
             )
-            response = get_llm().generate(prompt, max_tokens=100)
-            if response and response.content and len(response.content.strip()) > 15:
-                description = response.content.strip()
+            if booker_result.get("name"):
+                name = booker_result["name"]
+            if booker_result.get("description"):
+                description = booker_result["description"]
+            if booker_result.get("storyline_type"):
+                storyline_type = booker_result["storyline_type"]
         except Exception:
-            pass  # Keep template description
+            pass  # Keep template values
 
     storyline = StorylineDB(
         world_id=world_id,

--- a/game_service/storyline_service.py
+++ b/game_service/storyline_service.py
@@ -131,6 +131,22 @@ def create_storyline(db: Session, world_id: str, federation_id: str,
         else:
             description = f"A new {storyline_type} storyline unfolds."
 
+    # Try LLM-enhanced storyline description if enabled
+    import os
+    if os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes"):
+        try:
+            from llm_abstraction.provider import get_llm
+            names = [w_names.get(wid, "Unknown") for wid in wrestler_ids[:2]]
+            prompt = (
+                f"Write a 1-2 sentence wrestling storyline description for a {storyline_type} "
+                f"between {' and '.join(names)}. Make it dramatic and concise."
+            )
+            response = get_llm().generate(prompt, max_tokens=100)
+            if response and response.content and len(response.content.strip()) > 15:
+                description = response.content.strip()
+        except Exception:
+            pass  # Keep template description
+
     storyline = StorylineDB(
         world_id=world_id,
         federation_id=federation_id,
@@ -297,6 +313,24 @@ def check_match_storyline_triggers(db: Session, match: MatchDB, game_date: str):
         quality_bonus = max(0, int((rating - 3.0) * 3))  # +3 per star above 3.0
         card_bonus = 3 if getattr(match, 'card_position', '') == 'main_event' else 0
         heat_delta = base_heat + quality_bonus + card_bonus
+
+        # Seasonal heat multiplier: storylines get a boost during PPV build windows
+        try:
+            from game_service.ppv_calendar_service import get_next_ppv, is_build_window
+            from models.game_models import ShowDB, ShowSegmentDB
+            seg = match.segment
+            if seg:
+                show = db.query(ShowDB).filter(ShowDB.id == seg.show_id).first()
+                if show:
+                    next_ppv = get_next_ppv(db, show.federation_id, show.game_date)
+                    if next_ppv and is_build_window(show.game_date, next_ppv.scheduled_date):
+                        if getattr(next_ppv, 'is_crown_jewel', False):
+                            heat_delta = int(heat_delta * 2.0)  # Crown Jewel build: +100%
+                        else:
+                            heat_delta = int(heat_delta * 1.5)  # Regular PPV build: +50%
+        except Exception:
+            pass  # PPV calendar system is optional
+
         progress_storyline(
             db, existing, "match_result", heat_delta,
             description=f"Their rivalry intensified after a {rating:.1f}-star match!",

--- a/game_service/storyline_service.py
+++ b/game_service/storyline_service.py
@@ -291,11 +291,15 @@ def check_match_storyline_triggers(db: Session, match: MatchDB, game_date: str):
     existing = _find_storyline_between(db, winner.wrestler_id, loser.wrestler_id)
 
     if existing:
-        # Progress existing storyline
-        heat_delta = 8 if match.is_title_match else 5
+        # Progress existing storyline — heat scales with match quality
+        rating = match.match_rating or 3.0
+        base_heat = 8 if match.is_title_match else 6
+        quality_bonus = max(0, int((rating - 3.0) * 3))  # +3 per star above 3.0
+        card_bonus = 3 if getattr(match, 'card_position', '') == 'main_event' else 0
+        heat_delta = base_heat + quality_bonus + card_bonus
         progress_storyline(
             db, existing, "match_result", heat_delta,
-            description=f"Their rivalry intensified after a {match.match_rating or 0:.1f}-star match!",
+            description=f"Their rivalry intensified after a {rating:.1f}-star match!",
         )
     else:
         # Small chance a competitive match spawns a new feud

--- a/game_service/viewership_service.py
+++ b/game_service/viewership_service.py
@@ -157,6 +157,22 @@ def calculate_card_draw(db: Session, show: ShowDB) -> float:
     if rivalry_bonus:
         card_draw += 5
 
+    # Viral social media buzz bonus
+    try:
+        from game_service.social_media_service import get_viral_buzz_bonus
+        all_wrestler_ids = []
+        for seg in match_segments:
+            match = db.query(MatchDB).filter(MatchDB.id == seg.match_id).first()
+            if match:
+                pids = [p.wrestler_id for p in db.query(MatchParticipantDB).filter(
+                    MatchParticipantDB.match_id == match.id).all()]
+                all_wrestler_ids.extend(pids)
+        if all_wrestler_ids:
+            buzz = get_viral_buzz_bonus(db, show.world_id, show.game_date, all_wrestler_ids)
+            card_draw *= (1.0 + buzz)
+    except Exception:
+        pass  # Social media system is optional
+
     return max(0.0, min(100.0, card_draw))
 
 

--- a/game_service/world_service.py
+++ b/game_service/world_service.py
@@ -65,6 +65,65 @@ REGIONS = ["Northeast", "Southeast", "Midwest", "Southwest", "West Coast", "Inte
 STYLES = ["Sports Entertainment", "Strong Style", "Lucha Libre", "Technical", "Hardcore", "Old School"]
 WEIGHT_CLASSES = ["lightweight", "cruiserweight", "middleweight", "heavyweight", "super_heavyweight"]
 
+# Named venue pools by region — gives shows real character
+VENUES = {
+    "Northeast": {
+        "club": ["The Hammerstein Ballroom", "The ECW Arena", "The Manhattan Center",
+                  "Webster Hall", "The Palladium"],
+        "arena": ["Madison Square Garden Theater", "Boardwalk Hall", "The Prudential Center",
+                   "Nassau Coliseum", "Barclays Center", "TD Garden"],
+        "stadium": ["MetLife Stadium", "Yankee Stadium", "Gillette Stadium"],
+    },
+    "Southeast": {
+        "club": ["Center Stage Theater", "The Impact Zone", "The Sportatorium",
+                  "The Cajun Dome Club", "The Warehouse"],
+        "arena": ["The Omni", "Greensboro Coliseum", "The Civic Center",
+                   "Amway Center", "Bridgestone Arena", "FedExForum"],
+        "stadium": ["The Georgia Dome", "Raymond James Stadium", "Bank of America Stadium"],
+    },
+    "Midwest": {
+        "club": ["The Odeum", "Davis Arena", "The Rave",
+                  "Harley Race Arena", "The Coliseum Club"],
+        "arena": ["Allstate Arena", "Rupp Arena", "The Kiel Center",
+                   "Joe Louis Arena", "The Bradley Center", "Bankers Life Fieldhouse"],
+        "stadium": ["Soldier Field", "Ford Field", "Lucas Oil Stadium"],
+    },
+    "Southwest": {
+        "club": ["The Bomb Factory", "The Aztec Theater", "The Pavilion",
+                  "South Side Ballroom", "The Pit"],
+        "arena": ["The Alamodome Theater", "American Airlines Center", "Dickies Arena",
+                   "The Toyota Center", "Desert Diamond Arena", "Moody Center"],
+        "stadium": ["AT&T Stadium", "NRG Stadium", "The Alamodome"],
+    },
+    "West Coast": {
+        "club": ["The Grand Olympic Auditorium", "The Shrine Expo", "The Cow Palace Club",
+                  "The Hollywood Palladium", "The Showbox"],
+        "arena": ["The Staples Center", "Oracle Arena", "The Forum",
+                   "T-Mobile Arena", "Moda Center", "Climate Pledge Arena"],
+        "stadium": ["SoFi Stadium", "Levi's Stadium", "Allegiant Stadium"],
+    },
+    "International": {
+        "club": ["The Budokan Hall", "York Hall", "Korakuen Hall",
+                  "Arena Mexico", "Wembley Arena Club"],
+        "arena": ["Tokyo Dome City Hall", "Manchester Arena", "The O2 Arena",
+                   "Osaka-Jo Hall", "Ryogoku Kokugikan", "Wembley Arena"],
+        "stadium": ["Tokyo Dome", "Wembley Stadium", "Melbourne Cricket Ground"],
+    },
+}
+
+
+def pick_venue(region: str, capacity: int) -> str:
+    """Pick a named venue appropriate for the capacity and region."""
+    region_venues = VENUES.get(region, VENUES["Northeast"])
+    if capacity <= 1500:
+        tier = "club"
+    elif capacity <= 15000:
+        tier = "arena"
+    else:
+        tier = "stadium"
+    pool = region_venues.get(tier, region_venues["arena"])
+    return random.choice(pool)
+
 
 def _random_stat(base: int = 50, variance: int = 25) -> int:
     """Generate a random stat with a normal distribution around base."""
@@ -99,6 +158,40 @@ def _generate_career_goals(age: int) -> list:
     return goals
 
 
+def _pick_archetype(alignment: str, stats_dict: dict) -> str:
+    """Pick a gimmick archetype based on alignment and dominant stats."""
+    # Determine dominant style from stats
+    style_scores = {
+        "power": stats_dict.get("power", 50) + stats_dict.get("toughness", 50),
+        "aerial": stats_dict.get("aerial", 50) + stats_dict.get("speed", 50),
+        "technical": stats_dict.get("technical", 50) + stats_dict.get("submission", 50),
+        "brawling": stats_dict.get("brawling", 50) + stats_dict.get("toughness", 50),
+        "charisma": stats_dict.get("charisma", 50) + stats_dict.get("mic_skill", 50),
+    }
+    dominant = max(style_scores, key=style_scores.get)
+
+    # Map dominant style + alignment to likely archetypes
+    archetype_map = {
+        ("power", "heel"): ["monster_heel", "cult_leader"],
+        ("power", "face"): ["patriot", "legacy"],
+        ("power", "tweener"): ["anti_hero", "silent_assassin"],
+        ("aerial", "heel"): ["cocky_technician", "daredevil"],
+        ("aerial", "face"): ["daredevil", "underdog_face"],
+        ("aerial", "tweener"): ["daredevil", "anti_hero"],
+        ("technical", "heel"): ["cocky_technician", "silent_assassin"],
+        ("technical", "face"): ["legacy", "underdog_face"],
+        ("technical", "tweener"): ["anti_hero", "cocky_technician"],
+        ("brawling", "heel"): ["monster_heel", "cult_leader"],
+        ("brawling", "face"): ["patriot", "underdog_face"],
+        ("brawling", "tweener"): ["anti_hero", "silent_assassin"],
+        ("charisma", "heel"): ["cult_leader", "cocky_technician"],
+        ("charisma", "face"): ["comedy_act", "underdog_face"],
+        ("charisma", "tweener"): ["anti_hero", "comedy_act"],
+    }
+    options = archetype_map.get((dominant, alignment), ["anti_hero"])
+    return random.choice(options)
+
+
 def _generate_npc_wrestler(world_id: str) -> tuple:
     """Generate a random NPC wrestler with stats."""
     name = f"{random.choice(WRESTLER_FIRST_NAMES)} {random.choice(WRESTLER_LAST_NAMES)}"
@@ -111,24 +204,60 @@ def _generate_npc_wrestler(world_id: str) -> tuple:
     phys = generate_physical_attributes()
     peak_age = random.randint(26, 32)
 
+    # Generate stats first so we can derive archetype
+    exp_bonus = min(exp * 2, 30)
+    stats_raw = {
+        "power": _random_stat(45 + exp_bonus // 2),
+        "speed": _random_stat(55 - age // 4),
+        "technical": _random_stat(40 + exp_bonus),
+        "aerial": _random_stat(50 - age // 3),
+        "brawling": _random_stat(45 + exp_bonus // 2),
+        "submission": _random_stat(40 + exp_bonus // 2),
+        "stamina": _random_stat(55 - age // 5),
+        "toughness": _random_stat(50 + exp_bonus // 3),
+        "charisma": _random_stat(50),
+        "mic_skill": _random_stat(45),
+        "psychology": _random_stat(35 + exp_bonus),
+        "selling": _random_stat(40 + exp_bonus // 2),
+        "backstage_politics": _random_stat(40),
+        "loyalty": _random_stat(50),
+        "work_ethic": _random_stat(60),
+        "injury_prone": _random_stat(30, 15),
+    }
+
+    alignment = random.choice(["face", "heel", "tweener"])
+    charisma_style = random.choice(["cocky", "humble", "intense", "funny", "mysterious"])
+
+    # Pick archetype and generate archetype-specific finisher + signatures
+    archetype = _pick_archetype(alignment, stats_raw)
+
+    from core_engine.match_engine import ARCHETYPE_FINISHERS, SIGNATURE_MOVE_POOLS
+    finisher_pool = ARCHETYPE_FINISHERS.get(archetype, ARCHETYPE_FINISHERS["anti_hero"])
+    finisher_name, finisher_type = random.choice(finisher_pool)
+
+    sig_pool = SIGNATURE_MOVE_POOLS.get(archetype, SIGNATURE_MOVE_POOLS["anti_hero"])
+    signature_moves = [list(sig) for sig in random.sample(sig_pool, min(3, len(sig_pool)))]
+
     wrestler = GameWrestlerDB(
         world_id=world_id,
         name=name,
         is_npc=True,
         gimmick=random.choice(GIMMICKS),
-        alignment=random.choice(["face", "heel", "tweener"]),
+        alignment=alignment,
         popularity=random.randint(20, 80),
         condition=random.randint(80, 100),
         morale=random.randint(50, 90),
         age=age,
         experience_years=exp,
         weight_class=random.choice(WEIGHT_CLASSES),
-        finisher_name=f"The {random.choice(['Devastator', 'Annihilator', 'Showstopper', 'Final Cut', 'Endgame', 'Lights Out', 'Total Eclipse', 'Death Drop'])}",
-        finisher_type=random.choice(["power", "submission", "aerial", "technical"]),
+        finisher_name=finisher_name,
+        finisher_type=finisher_type,
+        signature_moves=signature_moves,
         personality_traits={
             "aggression": random.randint(20, 90),
-            "charisma_style": random.choice(["cocky", "humble", "intense", "funny", "mysterious"]),
+            "charisma_style": charisma_style,
             "risk_tolerance": random.randint(20, 90),
+            "archetype": archetype,
         },
         career_goals=_generate_career_goals(age),
         # Group 1: Aging
@@ -141,26 +270,7 @@ def _generate_npc_wrestler(world_id: str) -> tuple:
     )
     update_career_phase(wrestler)
 
-    # Scale stats by experience
-    exp_bonus = min(exp * 2, 30)
-    stats = WrestlerStatsDB(
-        power=_random_stat(45 + exp_bonus // 2),
-        speed=_random_stat(55 - age // 4),
-        technical=_random_stat(40 + exp_bonus),
-        aerial=_random_stat(50 - age // 3),
-        brawling=_random_stat(45 + exp_bonus // 2),
-        submission=_random_stat(40 + exp_bonus // 2),
-        stamina=_random_stat(55 - age // 5),
-        toughness=_random_stat(50 + exp_bonus // 3),
-        charisma=_random_stat(50),
-        mic_skill=_random_stat(45),
-        psychology=_random_stat(35 + exp_bonus),
-        selling=_random_stat(40 + exp_bonus // 2),
-        backstage_politics=_random_stat(40),
-        loyalty=_random_stat(50),
-        work_ethic=_random_stat(60),
-        injury_prone=_random_stat(30, 15),
-    )
+    stats = WrestlerStatsDB(**stats_raw)
 
     return wrestler, stats
 

--- a/game_service/world_service.py
+++ b/game_service/world_service.py
@@ -4,6 +4,7 @@ World management service - creating worlds, players, and managing game state.
 
 import logging
 import random
+from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
 
 from models.game_models import (
@@ -238,6 +239,10 @@ def create_world(db: Session, name: str, description: str = None,
         # 80% chance of being signed to a federation
         if random.random() < 0.8 and federations:
             fed = random.choice(federations)
+            # Contract length: 26-78 weeks (6-18 months)
+            contract_weeks = random.randint(26, 78)
+            start = datetime.strptime(world.current_game_date, "%Y-%m-%d")
+            end_date = (start + timedelta(weeks=contract_weeks)).strftime("%Y-%m-%d")
             db.add(ContractDB(
                 world_id=world.id,
                 wrestler_id=wrestler.id,
@@ -245,6 +250,7 @@ def create_world(db: Session, name: str, description: str = None,
                 status="active",
                 salary_weekly=random.uniform(500, 10000),
                 start_date=world.current_game_date,
+                end_date=end_date,
                 is_exclusive=random.random() < 0.7,
             ))
         else:

--- a/game_service/world_ticker.py
+++ b/game_service/world_ticker.py
@@ -796,12 +796,18 @@ class WorldTicker:
     def _npc_book_ppv_show(self, fed: GameFederationDB, ppv):
         """Book and create a PPV show from the PPV calendar."""
         show_svc = _get_show_service()
+        ppv_capacity = ppv.capacity or 15000
+        if not ppv.venue:
+            from game_service.world_service import pick_venue
+            ppv_venue = pick_venue(fed.home_region or "Northeast", ppv_capacity)
+        else:
+            ppv_venue = ppv.venue
         show = show_svc.create_show(
             self.db, self.world.id, fed.id,
             name=ppv.name,
             show_type="ppv",
-            venue=ppv.venue or f"{fed.home_region} Arena",
-            capacity=ppv.capacity or 15000,
+            venue=ppv_venue,
+            capacity=ppv_capacity,
             game_date=self.world.current_game_date,
         )
         ppv.show_id = show.id
@@ -835,12 +841,15 @@ class WorldTicker:
             else:
                 show_name = f"{fed.short_name or fed.name} Weekly (Building to {next_ppv.name})"
 
+        weekly_cap = random.randint(2000, 10000)
+        from game_service.world_service import pick_venue
+        weekly_venue = pick_venue(fed.home_region or "Northeast", weekly_cap)
         show = show_svc.create_show(
             self.db, self.world.id, fed.id,
             name=show_name,
             show_type="weekly",
-            venue=f"{fed.home_region} Arena",
-            capacity=random.randint(2000, 10000),
+            venue=weekly_venue,
+            capacity=weekly_cap,
             game_date=self.world.current_game_date,
         )
         segments = show_svc.npc_book_card(self.db, show, next_ppv=next_ppv)

--- a/game_service/world_ticker.py
+++ b/game_service/world_ticker.py
@@ -6,10 +6,32 @@ storyline progression, economy, and world events.
 """
 
 import logging
+import os
 import random
 from datetime import datetime, timedelta
 from typing import List, Optional
 from sqlalchemy.orm import Session
+
+# LLM integration gate — set LLMFED_USE_LLM=1 to enable LLM-generated narrative
+USE_LLM = os.getenv("LLMFED_USE_LLM", "").lower() in ("1", "true", "yes")
+
+
+def _llm_generate(prompt: str, fallback: str, system_msg: str = None) -> str:
+    """Generate text via LLM if enabled, otherwise return fallback.
+
+    Never raises — any failure returns the fallback text silently.
+    """
+    if not USE_LLM:
+        return fallback
+    try:
+        from llm_abstraction.provider import get_llm
+        llm = get_llm()
+        response = llm.generate(prompt, system_message=system_msg, max_tokens=200)
+        if response and response.content:
+            return response.content.strip()
+    except Exception as e:
+        logging.getLogger(__name__).debug("LLM generation failed, using fallback: %s", e)
+    return fallback
 
 from models.game_models import (
     WorldDB, WorldStateDB, PlayerActionDB, GameFederationDB,
@@ -257,6 +279,10 @@ class WorldTicker:
             return self._action_create_storyline(data)
         elif action_type == "advance_storyline":
             return self._action_advance_storyline(data)
+        elif action_type == "request_match":
+            return self._action_request_match(data)
+        elif action_type == "open_challenge":
+            return self._action_open_challenge(data)
         else:
             return {"message": f"Action '{action_type}' acknowledged"}
 
@@ -407,6 +433,141 @@ class WorldTicker:
             importance=5,
         )
         return result
+
+    # --- Match request / open challenge actions ---
+
+    def _action_request_match(self, data: dict) -> dict:
+        """Player requests a match on the next show for their federation.
+
+        Books the player into an opening slot on the next weekly show.
+        Win = +2-4 popularity, Loss = +1 popularity (exposure value).
+        Cooldown: 1 request per game week (7 ticks).
+        """
+        wrestler_id = data.get("wrestler_id")
+        wrestler = self.db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.id == wrestler_id
+        ).first()
+        if not wrestler:
+            raise ValueError("Wrestler not found")
+
+        # Find wrestler's federation
+        contract = self.db.query(ContractDB).filter(
+            ContractDB.wrestler_id == wrestler_id,
+            ContractDB.status == "active",
+        ).first()
+        if not contract:
+            raise ValueError("Wrestler has no active contract")
+
+        # Store the request in world metadata for the show booking phase to pick up
+        meta = self.world.world_config or {}
+        match_requests = meta.get("pending_match_requests", [])
+
+        # Check cooldown — only 1 request per 7 days
+        game_date = self.world.current_game_date
+        for req in match_requests:
+            if req.get("wrestler_id") == wrestler_id:
+                last_date = req.get("date", "")
+                try:
+                    days_since = (datetime.strptime(game_date, "%Y-%m-%d") -
+                                  datetime.strptime(last_date, "%Y-%m-%d")).days
+                    if days_since < 7:
+                        return {"message": f"Match request on cooldown ({7 - days_since} days remaining)"}
+                except (ValueError, TypeError):
+                    pass
+
+        # Remove old request for this wrestler if any, add new one
+        match_requests = [r for r in match_requests if r.get("wrestler_id") != wrestler_id]
+        match_requests.append({
+            "wrestler_id": wrestler_id,
+            "federation_id": contract.federation_id,
+            "date": game_date,
+            "type": "request_match",
+        })
+        meta["pending_match_requests"] = match_requests
+        self.world.world_config = meta
+
+        self._log_event(
+            "match_request",
+            f"{wrestler.name} has requested a match on the next show!",
+            [wrestler_id], importance=4,
+        )
+        return {"message": f"{wrestler.name} is booked for a match on the next show", "status": "pending"}
+
+    def _action_open_challenge(self, data: dict) -> dict:
+        """Player issues an open challenge — higher risk/reward than request_match.
+
+        Matched against someone ±10 popularity. Win = +4-6 pop, Loss = +0.
+        Can spark a storyline if player popularity > 40.
+        """
+        wrestler_id = data.get("wrestler_id")
+        wrestler = self.db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.id == wrestler_id
+        ).first()
+        if not wrestler:
+            raise ValueError("Wrestler not found")
+
+        contract = self.db.query(ContractDB).filter(
+            ContractDB.wrestler_id == wrestler_id,
+            ContractDB.status == "active",
+        ).first()
+        if not contract:
+            raise ValueError("Wrestler has no active contract")
+
+        # Find a suitable opponent: ±10 popularity from same federation
+        roster_contracts = self.db.query(ContractDB).filter(
+            ContractDB.federation_id == contract.federation_id,
+            ContractDB.status == "active",
+            ContractDB.wrestler_id != wrestler_id,
+        ).all()
+
+        candidates = []
+        for c in roster_contracts:
+            opp = self.db.query(GameWrestlerDB).filter(
+                GameWrestlerDB.id == c.wrestler_id,
+                GameWrestlerDB.is_injured == False,
+            ).first()
+            if opp and abs(opp.popularity - wrestler.popularity) <= 15:
+                candidates.append(opp)
+
+        if not candidates:
+            # Fallback: anyone on the roster who isn't injured
+            for c in roster_contracts:
+                opp = self.db.query(GameWrestlerDB).filter(
+                    GameWrestlerDB.id == c.wrestler_id,
+                    GameWrestlerDB.is_injured == False,
+                ).first()
+                if opp:
+                    candidates.append(opp)
+
+        if not candidates:
+            return {"message": "No suitable opponents available for an open challenge"}
+
+        opponent = random.choice(candidates)
+
+        # Store in metadata for show booking
+        meta = self.world.world_config or {}
+        match_requests = meta.get("pending_match_requests", [])
+        match_requests = [r for r in match_requests if r.get("wrestler_id") != wrestler_id]
+        match_requests.append({
+            "wrestler_id": wrestler_id,
+            "federation_id": contract.federation_id,
+            "opponent_id": opponent.id,
+            "date": self.world.current_game_date,
+            "type": "open_challenge",
+        })
+        meta["pending_match_requests"] = match_requests
+        self.world.world_config = meta
+
+        self._log_event(
+            "open_challenge",
+            f"{wrestler.name} issues an open challenge! {opponent.name} answers!",
+            [wrestler_id, opponent.id], importance=6,
+        )
+        return {
+            "message": f"{wrestler.name} issues an open challenge — {opponent.name} has accepted!",
+            "opponent": opponent.name,
+            "opponent_id": opponent.id,
+        }
 
     # --- Faction / stable actions ---
 
@@ -664,9 +825,15 @@ class WorldTicker:
 
         show_name = f"{fed.short_name or fed.name} Weekly"
         if next_ppv and is_go_home_week(self.world.current_game_date, next_ppv.scheduled_date):
-            show_name = f"{fed.short_name or fed.name} Go-Home Show"
+            if getattr(next_ppv, 'is_crown_jewel', False):
+                show_name = f"{fed.short_name or fed.name} {next_ppv.name} Go-Home Special"
+            else:
+                show_name = f"{fed.short_name or fed.name} Go-Home Show"
         elif next_ppv and is_build_window(self.world.current_game_date, next_ppv.scheduled_date):
-            show_name = f"{fed.short_name or fed.name} Weekly (Building to {next_ppv.name})"
+            if getattr(next_ppv, 'is_crown_jewel', False):
+                show_name = f"Road to {next_ppv.name}"
+            else:
+                show_name = f"{fed.short_name or fed.name} Weekly (Building to {next_ppv.name})"
 
         show = show_svc.create_show(
             self.db, self.world.id, fed.id,
@@ -1243,6 +1410,100 @@ class WorldTicker:
             return 0
 
     # ------------------------------------------------------------------
+    # Tag team name generation
+    # ------------------------------------------------------------------
+
+    _TAG_TEAM_NAMES = {
+        "power": [
+            "The Wrecking Crew", "Heavy Artillery", "The Demolition Squad",
+            "Iron Curtain", "The Juggernaut Express", "Total Destruction",
+            "The War Machine", "Brute Force", "The Colossus Connection",
+        ],
+        "highflyer": [
+            "Air Raid", "Terminal Velocity", "Sky High",
+            "The Shooting Stars", "Double Vision", "The Aerials",
+            "Freefall", "Altitude Sickness", "The High Wire",
+        ],
+        "technical": [
+            "The Submission Squad", "Chain Reaction", "The Technicians",
+            "Master Class", "Precision Strike", "The Chess Club",
+            "Clinical Finish", "The Hold Exchange", "Mat Generals",
+        ],
+        "brawler": [
+            "Street Justice", "The Pitfighters", "Knuckle Up",
+            "Bar Room Blitz", "The Enforcers", "Concrete Justice",
+            "The Roughnecks", "Violent Tendencies", "The Brawl Brothers",
+        ],
+        "mixed": [
+            "Brains & Brawn", "The Odd Couple", "Chaos Theory",
+            "Yin & Yang", "The Contrast", "Unlikely Alliance",
+            "Controlled Chaos", "Thunder & Lightning", "The Paradox",
+        ],
+        "generic": [
+            "The Alliance", "Double Trouble", "The Partnership",
+            "Tandem", "The Foundation", "The Coalition",
+            "Second Wind", "The Union", "Full Circle",
+        ],
+    }
+
+    _TEAM_FINISHER_TEMPLATES = [
+        "Double {move}", "The {adj} Bomb", "{adj} Annihilation",
+        "Total {move}", "The Grand Finale", "Doomsday {move}",
+        "Double Down", "The Crescendo", "Curtain Call",
+    ]
+    _FINISHER_MOVES = ["Powerbomb", "Suplex", "Slam", "Piledriver", "Cutter", "DDT"]
+    _FINISHER_ADJS = ["Midnight", "Thunderous", "Final", "Atomic", "Devastating", "Crimson"]
+
+    def _generate_tag_team_name(self, w1: "GameWrestlerDB", w2: "GameWrestlerDB") -> tuple:
+        """Generate a creative tag team name and finisher based on wrestler styles."""
+        from models.game_models import GimmickHistoryDB
+
+        # Determine style category for each wrestler from stats
+        stats1 = self.db.query(WrestlerStatsDB).filter(WrestlerStatsDB.wrestler_id == w1.id).first()
+        stats2 = self.db.query(WrestlerStatsDB).filter(WrestlerStatsDB.wrestler_id == w2.id).first()
+
+        def _classify(stats):
+            if not stats:
+                return "generic"
+            top = max(
+                ("power", stats.power), ("highflyer", stats.aerial + stats.speed),
+                ("technical", stats.technical + stats.submission),
+                ("brawler", stats.brawling + stats.toughness),
+                key=lambda x: x[1],
+            )
+            return top[0]
+
+        cat1, cat2 = _classify(stats1), _classify(stats2)
+        if cat1 == cat2:
+            pool_key = cat1
+        else:
+            pool_key = "mixed"
+
+        # Pick from pool, avoiding names already used in this world
+        existing_names = {
+            t.name for t in self.db.query(TagTeamDB).filter(
+                TagTeamDB.world_id == self.world.id
+            ).all()
+        }
+        pool = [n for n in self._TAG_TEAM_NAMES.get(pool_key, []) if n not in existing_names]
+        if not pool:
+            pool = [n for n in self._TAG_TEAM_NAMES["generic"] if n not in existing_names]
+        if not pool:
+            # Absolute fallback
+            team_name = f"{w1.name} & {w2.name}"
+        else:
+            team_name = random.choice(pool)
+
+        # Generate team finisher name
+        template = random.choice(self._TEAM_FINISHER_TEMPLATES)
+        finisher_name = template.format(
+            move=random.choice(self._FINISHER_MOVES),
+            adj=random.choice(self._FINISHER_ADJS),
+        )
+
+        return team_name, finisher_name
+
+    # ------------------------------------------------------------------
     # Phase 10: Tag team management
     # ------------------------------------------------------------------
 
@@ -1304,10 +1565,11 @@ class WorldTicker:
             if w1.alignment != w2.alignment and "tweener" not in (w1.alignment, w2.alignment):
                 continue
 
-            team_name = f"{w1.name} & {w2.name}"
+            team_name, finisher_name = self._generate_tag_team_name(w1, w2)
             self.db.add(TagTeamDB(
                 world_id=self.world.id,
                 name=team_name,
+                team_finisher_name=finisher_name,
                 wrestler1_id=rel.wrestler1_id,
                 wrestler2_id=rel.wrestler2_id,
                 formed_date=game_date,
@@ -1643,6 +1905,27 @@ class WorldTicker:
             if inductee:
                 self.events.append(f"HALL OF FAME: {inductee.name} inducted!")
 
+        # --- Quarterly seasonal events ---
+        # Q1 (Jan): New Year's Resolution — wrestlers with unmet goals get morale boost
+        if game_date.endswith("-01-07"):
+            self._seasonal_new_year_resolution(game_date)
+
+        # Q2 (June): King of the Ring tournament
+        if game_date.endswith("-06-01"):
+            self._seasonal_king_of_the_ring(game_date)
+
+        # Q3 (Jul-Sep): Summer Slam month — attendance boost
+        month = game_date[5:7]
+        if month in ("07", "08") and get_day_of_week(game_date) == 0:
+            # Summer boost: all federations get a momentum nudge
+            npc_feds = self.db.query(GameFederationDB).filter(
+                GameFederationDB.world_id == self.world.id,
+                GameFederationDB.is_active == True,
+            ).all()
+            for fed in npc_feds:
+                old_m = fed.momentum or 50
+                fed.momentum = min(100, old_m + 2)
+
         # Dec 31: Year-end summary and awards
         if game_date.endswith("-12-31"):
             self._generate_year_end_summary(game_date)
@@ -1792,6 +2075,90 @@ class WorldTicker:
                 self.events.append(f"Manager bonds updated for {len(bonds)} pairing(s)")
         except Exception as e:
             logger.error("Manager tick failed: %s", e, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Seasonal events
+    # ------------------------------------------------------------------
+
+    def _seasonal_new_year_resolution(self, game_date: str):
+        """Q1 event: Wrestlers with unmet goals get a fresh-start morale boost."""
+        wrestlers = self.db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.world_id == self.world.id,
+            GameWrestlerDB.is_active == True,
+        ).all()
+
+        boosted = 0
+        for w in wrestlers:
+            if (w.morale or 50) < 60:
+                w.morale = min(100, (w.morale or 50) + 5)
+                boosted += 1
+
+        if boosted:
+            self._log_event(
+                "seasonal_event",
+                f"New Year's Resolution: {boosted} wrestlers start the year with renewed motivation!",
+                importance=5,
+            )
+            self.events.append(f"New Year's Resolution: {boosted} wrestlers got a morale boost")
+
+    def _seasonal_king_of_the_ring(self, game_date: str):
+        """Q2 event: King of the Ring tournament across all NPC feds.
+
+        Picks top 8 by popularity per federation, announces a tournament via
+        narrative log, and crowns a winner with +10 popularity.
+        """
+        npc_feds = self.db.query(GameFederationDB).filter(
+            GameFederationDB.world_id == self.world.id,
+            GameFederationDB.is_npc == True,
+            GameFederationDB.is_active == True,
+        ).all()
+
+        for fed in npc_feds:
+            contracts = self.db.query(ContractDB).filter(
+                ContractDB.federation_id == fed.id,
+                ContractDB.status == "active",
+            ).all()
+            wrestler_ids = [c.wrestler_id for c in contracts]
+            wrestlers = self.db.query(GameWrestlerDB).filter(
+                GameWrestlerDB.id.in_(wrestler_ids),
+                GameWrestlerDB.is_active == True,
+                GameWrestlerDB.is_injured == False,
+            ).order_by(GameWrestlerDB.popularity.desc()).limit(8).all()
+
+            if len(wrestlers) < 4:
+                continue
+
+            # Simulate single-elimination tournament (simplified)
+            bracket = list(wrestlers)
+            round_num = 1
+            while len(bracket) > 1:
+                next_round = []
+                for i in range(0, len(bracket) - 1, 2):
+                    w1, w2 = bracket[i], bracket[i + 1]
+                    # Higher popularity + randomness wins
+                    w1_score = w1.popularity + random.randint(-20, 20)
+                    w2_score = w2.popularity + random.randint(-20, 20)
+                    winner = w1 if w1_score >= w2_score else w2
+                    next_round.append(winner)
+                # Handle odd bracket
+                if len(bracket) % 2 == 1:
+                    next_round.append(bracket[-1])
+                bracket = next_round
+                round_num += 1
+
+            king = bracket[0]
+            old_pop = king.popularity
+            king.popularity = min(100, king.popularity + 10)
+
+            self._log_event(
+                "seasonal_event",
+                f"KING OF THE RING: {king.name} wins the {fed.short_name or fed.name} "
+                f"King of the Ring tournament! (Pop {old_pop} → {king.popularity})",
+                [king.id], importance=8,
+            )
+            self.events.append(
+                f"King of the Ring: {king.name} crowned in {fed.short_name or fed.name}!"
+            )
 
     # ------------------------------------------------------------------
     # Year-end summary

--- a/game_service/world_ticker.py
+++ b/game_service/world_ticker.py
@@ -216,6 +216,9 @@ class WorldTicker:
         # 16. Manager effectiveness tracking (Thursdays)
         self._manager_tick(new_date)
 
+        # 17. Character agency — LLM-driven wrestler decisions
+        self._character_agency_tick(new_date)
+
         self.db.commit()
 
         return {
@@ -985,6 +988,28 @@ class WorldTicker:
                         aftermath.process_match_aftermath(
                             self.db, match, self.world.current_game_date
                         )
+
+                        # Character reactions — LLM-driven wrestlers react to match results
+                        if USE_LLM:
+                            try:
+                                from game_service.character_agent import character_react
+                                winner = self.db.query(GameWrestlerDB).filter(
+                                    GameWrestlerDB.id == result.winner_id
+                                ).first()
+                                if winner:
+                                    event_type = "title_win" if match.is_title_match else "win"
+                                    reaction = character_react(
+                                        self.db, winner.id, event_type,
+                                        f"Defeated opponent via {result.finish_type}. "
+                                        f"Match rating: {result.match_rating:.1f} stars.",
+                                    )
+                                    if reaction:
+                                        self._log_event(
+                                            "character_reaction", reaction,
+                                            [winner.id], importance=4,
+                                        )
+                            except Exception:
+                                pass  # Character reactions are optional
 
                         # Process stable effects from match result
                         try:
@@ -2084,6 +2109,28 @@ class WorldTicker:
                 self.events.append(f"Manager bonds updated for {len(bonds)} pairing(s)")
         except Exception as e:
             logger.error("Manager tick failed: %s", e, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Phase 17: Character agency — LLM-driven wrestler decisions
+    # ------------------------------------------------------------------
+
+    def _character_agency_tick(self, game_date: str):
+        """LLM-driven characters make autonomous decisions.
+
+        This is the core of 'LLMFed' — wrestlers are LLM-driven agents that
+        call out rivals, propose alliances, demand title shots, react to events,
+        and generate in-character content. When LLMFED_USE_LLM is not set,
+        template-based fallbacks drive the same mechanical effects.
+        """
+        try:
+            from game_service.character_agent import tick_character_agency
+            agent_events = tick_character_agency(
+                self.db, self.world.id, game_date,
+            )
+            for evt in agent_events:
+                self.events.append(f"[CHARACTER] {evt}")
+        except Exception as e:
+            logger.error("Character agency tick failed: %s", e, exc_info=True)
 
     # ------------------------------------------------------------------
     # Seasonal events

--- a/game_service/world_ticker.py
+++ b/game_service/world_ticker.py
@@ -329,8 +329,8 @@ class WorldTicker:
         try:
             from game_service.wrestler_lifecycle_service import training_with_mentor
             gain += training_with_mentor(self.db, wrestler_id, stat_name)
-        except Exception:
-            pass
+        except (ValueError, AttributeError) as e:
+            logger.debug("Mentor bonus skipped for %s: %s", wrestler_id, e)
 
         new_val = min(100, current + gain)
         setattr(stats, stat_name, new_val)
@@ -345,10 +345,68 @@ class WorldTicker:
         return {"stat": stat_name, "old": current, "new": new_val, "gain": new_val - current}
 
     def _action_cut_promo(self, data: dict) -> dict:
-        """Wrestler cuts a promo (processed by LLM later)."""
-        # For now, return acknowledgement. Full LLM promo generation
-        # will be in the storyline engine.
-        return {"message": "Promo direction noted", "direction": data.get("direction", "")}
+        """Wrestler cuts a promo — gains popularity, boosts storyline heat."""
+        wrestler_id = data.get("wrestler_id")
+        target_id = data.get("target_wrestler_id")
+        direction = data.get("direction", "")
+
+        wrestler = self.db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.id == wrestler_id
+        ).first()
+        if not wrestler:
+            raise ValueError("Wrestler not found")
+
+        stats = self.db.query(WrestlerStatsDB).filter(
+            WrestlerStatsDB.wrestler_id == wrestler_id
+        ).first()
+
+        # Promo quality based on charisma + mic skill
+        charisma = stats.charisma if stats else 50
+        mic = stats.mic_skill if stats else 50
+        base_quality = (charisma + mic) / 2
+        roll = random.randint(-15, 15)
+        quality = max(1, min(100, base_quality + roll))
+
+        # Popularity gain: 1-5 based on quality
+        pop_gain = 1
+        if quality >= 80:
+            pop_gain = random.randint(3, 5)
+        elif quality >= 60:
+            pop_gain = random.randint(2, 4)
+        elif quality >= 40:
+            pop_gain = random.randint(1, 3)
+
+        old_pop = wrestler.popularity
+        wrestler.popularity = min(100, wrestler.popularity + pop_gain)
+        wrestler.morale = min(100, (wrestler.morale or 50) + 2)
+
+        result = {
+            "quality": quality,
+            "popularity_gain": pop_gain,
+            "old_popularity": old_pop,
+            "new_popularity": wrestler.popularity,
+            "direction": direction,
+        }
+
+        # If targeting a rival, boost storyline heat
+        if target_id:
+            sl_svc = _get_storyline_service()
+            existing = sl_svc._find_storyline_between(self.db, wrestler_id, target_id)
+            if existing:
+                heat_boost = 5 if quality >= 60 else 3
+                sl_svc.progress_storyline(
+                    self.db, existing, "promo", heat_boost,
+                    description=f"{wrestler.name} cut a fiery promo targeting their rival!",
+                )
+                result["storyline_heat_boost"] = heat_boost
+
+        self._log_event(
+            "promo",
+            f"{wrestler.name} cuts a promo (quality: {quality}, pop +{pop_gain})",
+            [wrestler_id] + ([target_id] if target_id else []),
+            importance=5,
+        )
+        return result
 
     # --- Faction / stable actions ---
 
@@ -764,8 +822,8 @@ class WorldTicker:
                                     self.db, result.winner_id, loser_id,
                                     self.world.id, self.world.current_game_date,
                                 )
-                        except Exception:
-                            pass
+                        except (ValueError, AttributeError) as e:
+                            logger.debug("Stable match processing skipped: %s", e)
 
                         # Log post-match angle if one occurred
                         if result.post_match_angle:
@@ -783,7 +841,10 @@ class WorldTicker:
                             self.db, match, self.world.current_game_date
                         )
                     except Exception as e:
-                        logger.warning(f"Match simulation failed: {e}")
+                        logger.error(
+                            "Match simulation failed for match %s: %s",
+                            match.id, e, exc_info=True,
+                        )
                         seg.is_completed = True
                         seg.rating = round(random.uniform(2.0, 4.0), 1)
                         match_ratings.append(seg.rating)
@@ -854,7 +915,7 @@ class WorldTicker:
             news_svc = _get_news_service()
             news_svc.generate_show_news(self.db, show, match_ratings, fed)
         except Exception as e:
-            logger.warning(f"News generation failed: {e}")
+            logger.error("News generation failed for show %s: %s", show.id, e, exc_info=True)
 
         self._log_event(
             "show",
@@ -931,9 +992,14 @@ class WorldTicker:
         ).all()
 
         for storyline in active:
-            # Storylines heat decays if not progressed
-            if random.random() < 0.1:  # 10% chance per day
-                storyline.heat = max(0, storyline.heat - 1)
+            # Storylines heat decays daily — unserviced storylines fade faster
+            decay_chance = 0.3  # 30% chance per day (was 10%)
+            decay_amount = 1
+            if storyline.status == "climax":
+                decay_chance = 0.5  # Climax storylines need constant fuel
+                decay_amount = 2
+            if random.random() < decay_chance:
+                storyline.heat = max(0, storyline.heat - decay_amount)
 
             # Storylines can naturally escalate
             if storyline.status == "brewing" and storyline.heat > 60:
@@ -1083,7 +1149,17 @@ class WorldTicker:
                 GameWrestlerDB.id == contract.wrestler_id
             ).first()
             if wrestler:
-                self.events.append(f"Contract expired: {wrestler.name}")
+                fed = self.db.query(GameFederationDB).filter(
+                    GameFederationDB.id == contract.federation_id
+                ).first()
+                fed_name = (fed.short_name or fed.name) if fed else "Unknown"
+                self._log_event(
+                    "contract_expired",
+                    f"{wrestler.name}'s contract with {fed_name} has expired — now a free agent!",
+                    [wrestler.id, contract.federation_id],
+                    importance=6,
+                )
+                self.events.append(f"Contract expired: {wrestler.name} is now a free agent")
 
     # ------------------------------------------------------------------
     # Phase 8: Recovery
@@ -1527,7 +1603,7 @@ class WorldTicker:
             news_svc = _get_news_service()
             news_svc.generate_weekly_dirt_sheet(self.db, self.world.id, game_date)
         except Exception as e:
-            logger.warning(f"Weekly news generation failed: {e}")
+            logger.error("Weekly news generation failed: %s", e, exc_info=True)
 
     # ------------------------------------------------------------------
     # Phase 13: Wrestler lifecycle (Groups 1-6)
@@ -1543,16 +1619,33 @@ class WorldTicker:
         )
 
         # --- Annual events ---
-        # Jan 1: Age all wrestlers (Group 1)
+        # Jan 1: Age all wrestlers (Group 1) + PPV calendar rollover
         if game_date.endswith("-01-01"):
             age_wrestlers(self.db, self.world.id, game_date)
             self.events.append("Annual aging applied to all wrestlers")
+
+            # Generate next year's PPV calendars for all active federations
+            from game_service.ppv_calendar_service import rollover_ppv_calendar
+            all_feds = self.db.query(GameFederationDB).filter(
+                GameFederationDB.world_id == self.world.id,
+                GameFederationDB.is_active == True,
+            ).all()
+            for fed in all_feds:
+                new_ppvs = rollover_ppv_calendar(self.db, fed, game_date)
+                if new_ppvs:
+                    self.events.append(
+                        f"{fed.short_name or fed.name}: {len(new_ppvs)} PPVs scheduled for new year"
+                    )
 
         # April 1: Hall of Fame ceremony (Group 5)
         if game_date.endswith("-04-01"):
             inductee = hall_of_fame_ceremony(self.db, self.world.id, game_date)
             if inductee:
                 self.events.append(f"HALL OF FAME: {inductee.name} inducted!")
+
+        # Dec 31: Year-end summary and awards
+        if game_date.endswith("-12-31"):
+            self._generate_year_end_summary(game_date)
 
         # --- Weekly events (Thursdays) ---
         if get_day_of_week(game_date) == 3:
@@ -1619,7 +1712,7 @@ class WorldTicker:
                 tick_persona(self.db, self.world.id, game_date)
                 self.events.append("Persona lifecycle tick processed")
             except Exception as e:
-                logger.warning(f"Persona tick failed: {e}")
+                logger.error("Persona tick failed: %s", e, exc_info=True)
 
             # Check for worked-shoot storylines from life events
             try:
@@ -1639,7 +1732,7 @@ class WorldTicker:
                 for sl in coll_storylines:
                     self.events.append(f"Collision storyline '{sl.name}' created!")
             except Exception as e:
-                logger.warning(f"Kayfabe collision check failed: {e}")
+                logger.error("Kayfabe collision check failed: %s", e, exc_info=True)
 
         # Daily social media tick
         try:
@@ -1648,7 +1741,7 @@ class WorldTicker:
                 self.db, self.world.id, game_date
             )
         except Exception as e:
-            logger.warning(f"Social media tick failed: {e}")
+            logger.error("Social media tick failed: %s", e, exc_info=True)
 
     def _stable_dynamics_tick(self, game_date: str):
         """Process internal faction politics for all active stables.
@@ -1671,7 +1764,7 @@ class WorldTicker:
             if stables:
                 self.events.append(f"Faction dynamics processed for {len(stables)} stable(s)")
         except Exception as e:
-            logger.warning("Stable dynamics tick failed: %s", e)
+            logger.error("Stable dynamics tick failed: %s", e, exc_info=True)
 
     def _manager_tick(self, game_date: str):
         """Track manager effectiveness and bond evolution.
@@ -1698,7 +1791,118 @@ class WorldTicker:
             if bonds:
                 self.events.append(f"Manager bonds updated for {len(bonds)} pairing(s)")
         except Exception as e:
-            logger.warning("Manager tick failed: %s", e)
+            logger.error("Manager tick failed: %s", e, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Year-end summary
+    # ------------------------------------------------------------------
+
+    def _generate_year_end_summary(self, game_date: str):
+        """Generate year-end awards and summary news. Fires on Dec 31."""
+        news_svc = _get_news_service()
+        year = game_date[:4]
+
+        # Find all completed shows this year
+        year_start = f"{year}-01-01"
+        shows = self.db.query(ShowDB).filter(
+            ShowDB.world_id == self.world.id,
+            ShowDB.is_completed == True,
+            ShowDB.game_date >= year_start,
+            ShowDB.game_date <= game_date,
+        ).all()
+
+        # Best show of the year
+        best_show = max(shows, key=lambda s: s.overall_rating or 0) if shows else None
+
+        # Most popular wrestler (current popularity)
+        wrestlers = self.db.query(GameWrestlerDB).filter(
+            GameWrestlerDB.world_id == self.world.id,
+            GameWrestlerDB.is_active == True,
+        ).order_by(GameWrestlerDB.popularity.desc()).all()
+        wrestler_of_year = wrestlers[0] if wrestlers else None
+
+        # Best match of the year
+        best_match = self.db.query(MatchDB).filter(
+            MatchDB.world_id == self.world.id,
+            MatchDB.is_completed == True,
+            MatchDB.match_rating != None,
+            MatchDB.game_date >= year_start,
+        ).order_by(MatchDB.match_rating.desc()).first()
+
+        # Most dominant (highest win count)
+        from sqlalchemy import func
+        win_counts = (
+            self.db.query(
+                MatchParticipantDB.wrestler_id,
+                func.count(MatchParticipantDB.id).label("wins"),
+            )
+            .join(MatchDB)
+            .filter(
+                MatchParticipantDB.is_winner == True,
+                MatchDB.is_completed == True,
+                MatchDB.game_date >= year_start,
+                MatchDB.game_date <= game_date,
+            )
+            .group_by(MatchParticipantDB.wrestler_id)
+            .order_by(func.count(MatchParticipantDB.id).desc())
+            .first()
+        )
+
+        most_wins_wrestler = None
+        most_wins_count = 0
+        if win_counts:
+            most_wins_wrestler = self.db.query(GameWrestlerDB).filter(
+                GameWrestlerDB.id == win_counts[0]
+            ).first()
+            most_wins_count = win_counts[1]
+
+        # Federation of the year (highest momentum)
+        feds = self.db.query(GameFederationDB).filter(
+            GameFederationDB.world_id == self.world.id,
+            GameFederationDB.is_active == True,
+        ).order_by(GameFederationDB.momentum.desc()).all()
+        fed_of_year = feds[0] if feds else None
+
+        # Build summary
+        awards = []
+        if wrestler_of_year:
+            awards.append(f"Wrestler of the Year: {wrestler_of_year.name} (Popularity: {wrestler_of_year.popularity})")
+        if best_show:
+            fed = self.db.query(GameFederationDB).filter(
+                GameFederationDB.id == best_show.federation_id
+            ).first()
+            fed_name = (fed.short_name or fed.name) if fed else "Unknown"
+            awards.append(f"Show of the Year: {best_show.name} by {fed_name} ({best_show.overall_rating:.1f} stars)")
+        if best_match and best_match.match_rating:
+            awards.append(f"Match of the Year: {best_match.match_rating:.1f}-star classic")
+        if most_wins_wrestler:
+            awards.append(f"Most Dominant: {most_wins_wrestler.name} ({most_wins_count} wins)")
+        if fed_of_year:
+            awards.append(f"Federation of the Year: {fed_of_year.short_name or fed_of_year.name} (Momentum: {fed_of_year.momentum})")
+
+        summary = f"YEAR IN REVIEW {year}\n" + "\n".join(f"  - {a}" for a in awards)
+
+        self._log_event(
+            "year_end_awards",
+            summary,
+            [],
+            importance=10,
+        )
+
+        # Generate news article
+        self.db.add(WorldNewsDB(
+            world_id=self.world.id,
+            headline=f"YEAR IN REVIEW: The {year} Wrestling Awards!",
+            body="\n\n".join(awards),
+            category="year_end",
+            game_date=game_date,
+            is_kayfabe=False,
+            source="Wrestling Observer Year-End Issue",
+        ))
+
+        self.events.append(f"Year-end awards generated for {year}")
+        for award in awards:
+            self.events.append(f"AWARD: {award}")
 
     # ------------------------------------------------------------------
     # Helpers

--- a/models/game_models.py
+++ b/models/game_models.py
@@ -835,6 +835,7 @@ class TagTeamDB(Base):
     wrestler1_id = Column(String, ForeignKey("game_wrestlers.id"), nullable=False, index=True)
     wrestler2_id = Column(String, ForeignKey("game_wrestlers.id"), nullable=False, index=True)
     team_chemistry = Column(Integer, default=30)  # 0-100
+    team_finisher_name = Column(String(100), nullable=True)
     wins = Column(Integer, default=0)
     losses = Column(Integer, default=0)
     formed_date = Column(String(10), nullable=True)


### PR DESCRIPTION
After tracing every code path across 365 simulated days, this commit
addresses the top issues identified in the year-long simulation audit:

1. PPV calendar rollover: rollover_ppv_calendar() was never called from
   world_ticker, breaking year 2+ simulations entirely. Now fires Jan 1.

2. Storyline heat economy: Heat gains scaled up (6-17 pts per match vs
   flat 5), heat decay tripled (30% chance/day vs 10%), and NPC booking
   is now storyline-aware — feuding wrestlers get booked against each
   other on weekly TV during build windows.

3. Error handling: Replaced 11 bare `except Exception` blocks with
   targeted exception types (ValueError/AttributeError) or upgraded
   logger.warning to logger.error with exc_info=True for visibility.

4. Contract end_dates: Initial contracts now have 26-78 week durations
   instead of being permanent, enabling the free agency cycle.

5. cut_promo action: Was a dead stub returning a static string. Now
   calculates promo quality from charisma+mic_skill, grants 1-5
   popularity, boosts storyline heat when targeting a rival.

6. Match finish diversity: Changed from 75% pinfall / 25% submission to
   60% pin / 15% sub / 10% count-out / 15% DQ (title matches stay clean).

7. Year-end awards: Dec 31 generates Wrestler/Show/Match/Federation of
   the Year awards with narrative log and news article.

https://claude.ai/code/session_01YHkxnHr91YWmBn1RQhL82L